### PR TITLE
Remove hard dependency on Node.js 'crypto'

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,9 @@
     "ts-node": "^10.9.1",
     "tsc-alias": "^1.8.2",
     "typescript": "^4.9.4"
+  },
+  "react-native": {
+    "crypto": false,
+    "util": false
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@railgun-community/shared-models": "5.2.8",
     "@whatwg-node/fetch": "^0.8.4",
     "ethers": "6.6.2",
+    "ethereum-cryptography": "^2.0.0",
     "axios": "0.27.2",
     "brotli": "^1.3.3",
     "graphql": "^16.6.0"

--- a/src/services/artifacts/artifact-hash.ts
+++ b/src/services/artifacts/artifact-hash.ts
@@ -1,7 +1,8 @@
 import { ArtifactName, isDefined } from '@railgun-community/shared-models';
-import { createHash } from 'crypto';
+import { sha256 } from 'ethereum-cryptography/sha256.js';
 import { sendErrorMessage } from '../../utils/logger';
 import ARTIFACT_V2_HASHES from './json/artifact-v2-hashes.json';
+import { hexStringToBytes, hexlify } from '@railgun-community/engine';
 
 type ArtifactHashesJson = Record<
   string,
@@ -39,7 +40,10 @@ export const validateArtifactDownload = async (
   if (artifactName === ArtifactName.VKEY) {
     return true;
   }
-  const hash = createHash('sha256').update(data).digest('hex');
+  const dataBytes = Buffer.isBuffer(data)
+    ? new Uint8Array(data.buffer)
+    : hexStringToBytes(data);
+  const hash = hexlify(sha256(dataBytes));
   const expectedHash = getExpectedArtifactHash(
     artifactName,
     artifactVariantString,

--- a/src/services/artifacts/artifact-hash.ts
+++ b/src/services/artifacts/artifact-hash.ts
@@ -1,8 +1,13 @@
+import { createHash } from 'crypto';
 import { ArtifactName, isDefined } from '@railgun-community/shared-models';
 import { sha256 } from 'ethereum-cryptography/sha256.js';
 import { sendErrorMessage } from '../../utils/logger';
 import ARTIFACT_V2_HASHES from './json/artifact-v2-hashes.json';
-import { hexStringToBytes, hexlify } from '@railgun-community/engine';
+import {
+  hexStringToBytes,
+  hexlify,
+  isReactNative,
+} from '@railgun-community/engine';
 
 type ArtifactHashesJson = Record<
   string,
@@ -43,7 +48,9 @@ export const validateArtifactDownload = async (
   const dataBytes = Buffer.isBuffer(data)
     ? new Uint8Array(data.buffer)
     : hexStringToBytes(data);
-  const hash = hexlify(sha256(dataBytes));
+  const hash = isReactNative
+    ? hexlify(sha256(dataBytes))
+    : createHash('sha256').update(dataBytes).digest('hex');
   const expectedHash = getExpectedArtifactHash(
     artifactName,
     artifactVariantString,

--- a/src/services/railgun/util/crypto.ts
+++ b/src/services/railgun/util/crypto.ts
@@ -12,7 +12,7 @@ import {
 } from '@railgun-community/engine';
 import { EncryptDataWithSharedKeyResponse } from '@railgun-community/shared-models';
 import { getRandomBytes } from './bytes';
-import crypto from 'crypto';
+import { pbkdf2 as _pbkdf2 } from 'ethereum-cryptography/pbkdf2.js';
 
 export const verifyRelayerSignature = (
   signature: string | Uint8Array,
@@ -66,15 +66,12 @@ export const pbkdf2 = async (
   const keyLength = 32; // Bytes
   const digest = 'sha256';
 
-  const key: Buffer = await new Promise(resolve =>
-    crypto.pbkdf2(
-      secretFormatted,
-      saltFormatted,
-      iterations,
-      keyLength,
-      digest,
-      (_err: Error | null, derivedKey: Buffer) => resolve(derivedKey),
-    ),
+  const key: Uint8Array = await _pbkdf2(
+    secretFormatted,
+    saltFormatted,
+    iterations,
+    keyLength,
+    digest,
   );
   return hexlify(key);
 };

--- a/src/services/railgun/util/crypto.ts
+++ b/src/services/railgun/util/crypto.ts
@@ -9,10 +9,13 @@ import {
   verifyED25519,
   EncryptedData,
   ViewingKeyPair,
+  isReactNative
 } from '@railgun-community/engine';
 import { EncryptDataWithSharedKeyResponse } from '@railgun-community/shared-models';
 import { getRandomBytes } from './bytes';
-import { pbkdf2 as _pbkdf2 } from 'ethereum-cryptography/pbkdf2.js';
+import { promisify } from 'util';
+import { pbkdf2 as NodePbkdf2 } from 'crypto';
+import { pbkdf2 as JSpbkdf2 } from 'ethereum-cryptography/pbkdf2';
 
 export const verifyRelayerSignature = (
   signature: string | Uint8Array,
@@ -66,13 +69,24 @@ export const pbkdf2 = async (
   const keyLength = 32; // Bytes
   const digest = 'sha256';
 
-  const key: Uint8Array = await _pbkdf2(
-    secretFormatted,
-    saltFormatted,
-    iterations,
-    keyLength,
-    digest,
-  );
+  let key: Uint8Array | Buffer;
+  if (isReactNative) {
+    key = await JSpbkdf2(
+      secretFormatted,
+      saltFormatted,
+      iterations,
+      keyLength,
+      digest,
+    );
+  } else {
+    key = await promisify(NodePbkdf2)(
+      secretFormatted,
+      saltFormatted,
+      iterations,
+      keyLength,
+      digest,
+    );
+  }
   return hexlify(key);
 };
 


### PR DESCRIPTION
Similar to https://github.com/Railgun-Community/engine/pull/43, this PR replaces uses of Node.js `crypto` with JS-only `ethereum-cryptography`, which is already a dependency of `engine` (thus transitively also a dependency of `wallet`).

**Pending on https://github.com/Railgun-Community/engine/pull/43 merged first, and released, and updated here as a dependency.**

## Tests

- [ ] Unit tests
- [x] Started a new React Native project and imported this, apparently working
- [x] Existing iOS app continues to work
- [x] Existing Android app continues to work
- [x] Existing web app continues to work
- [x] Performance not noticeably affected (full re-scan on web lasted 42s, as usual)