### PR TITLE
react-native-shims and postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "axios": "0.27.2",
     "brotli": "^1.3.3",
     "graphql": "^16.6.0",
+    "react-native-get-random-values": "~1.9.0",
     "stream-browserify": "3.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "axios": "0.27.2",
     "brotli": "^1.3.3",
     "graphql": "^16.6.0",
-    "react-native-get-random-values": "~1.9.0",
     "stream-browserify": "3.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,12 @@
   "main": "dist/index.js",
   "license": "MIT",
   "files": [
-    "dist/**/*"
+    "dist/**/*",
+    "*.js"
   ],
   "exports": {
-    ".": "./dist/index.js"
+    ".": "./dist/index.js",
+    "./react-native-shims": "./react-native-shims.js"
   },
   "scripts": {
     "clean": "rm -rf dist",
@@ -22,6 +24,7 @@
     "eslint": "eslint src/**/* --ext .ts,.tsx --fix",
     "lint": "npm run check-circular-deps && npm run eslint && npm run tsc && npm run tsc-test",
     "prepare": "npm run compile",
+    "postinstall": "node postinstall.js",
     "build-graphql": "graphclient build && rm -rf src/services/railgun/quick-sync/graphql/.graphclient && mv .graphclient src/services/railgun/quick-sync/graphql"
   },
   "dependencies": {
@@ -38,11 +41,16 @@
     "@railgun-community/engine": "5.1.17",
     "@railgun-community/shared-models": "5.2.8",
     "@whatwg-node/fetch": "^0.8.4",
+    "assert": "2.0.0",
+    "buffer": "^6.0.3",
+    "crypto-browserify": "3.12.0",
     "ethers": "6.6.2",
     "ethereum-cryptography": "^2.0.0",
+    "events": "3.3.0",
     "axios": "0.27.2",
     "brotli": "^1.3.3",
-    "graphql": "^16.6.0"
+    "graphql": "^16.6.0",
+    "stream-browserify": "3.0.0"
   },
   "devDependencies": {
     "@graphprotocol/client-cli": "^2.2.20",

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,36 @@
+/* eslint-disable */
+const fs = require('node:fs');
+const path = require('node:path');
+
+const cwd = process.env.INIT_CWD;
+const reactNativeFiles = ['ios', 'android', 'metro.config.js'];
+const isReactNativeProject = reactNativeFiles.every(file =>
+  fs.existsSync(path.join(cwd, file)),
+);
+
+/**
+ * Patch `cipher-base` so that `stream` is replaced with `stream-browserify`
+ */
+function patchCipherBase() {
+  if (!fs.existsSync(path.join(cwd, 'node_modules'))) return;
+  if (!fs.existsSync(path.join(cwd, 'node_modules', 'cipher-base'))) return;
+
+  const cipherBasePackageJson = JSON.parse(
+    fs.readFileSync(
+      path.join(cwd, 'node_modules', 'cipher-base', 'package.json'),
+      'utf8',
+    ),
+  );
+  cipherBasePackageJson['react-native'] = {
+    stream: 'stream-browserify',
+  };
+  fs.writeFileSync(
+    path.join(cwd, 'node_modules', 'cipher-base', 'package.json'),
+    JSON.stringify(cipherBasePackageJson, null, 2),
+    'utf8',
+  );
+}
+
+if (isReactNativeProject) {
+  patchCipherBase();
+}

--- a/postinstall.js
+++ b/postinstall.js
@@ -31,6 +31,22 @@ function patchCipherBase() {
   );
 }
 
+function warnIfNoGetRandomValues() {
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(cwd, 'package.json'), 'utf8'),
+  );
+  if ('react-native-get-random-values' in packageJson['dependencies']) return;
+  throw new Error(
+    'react-native-get-random-values is missing. It seems like you are ' +
+      'installing @railgun-community/wallet in a React Native project. ' +
+      'This requires the peer dependency react-native-get-random-values. ' +
+      '\n' +
+      'Please add it to your package.json dependencies and run npm install ' +
+      '(or yarn) again.',
+  );
+}
+
 if (isReactNativeProject) {
   patchCipherBase();
+  warnIfNoGetRandomValues();
 }

--- a/react-native-shims.js
+++ b/react-native-shims.js
@@ -1,0 +1,42 @@
+/* eslint-disable */
+
+// Wallet (and Engine) uses Buffer,
+// which is not available in React Native.
+global.Buffer ??= require('buffer').Buffer;
+
+// Wallet uses ethereum-cryptography,
+// which needs @noble/hashes,
+// which needs crypto.getRandomValues,
+// which is not available in React Native.
+require('react-native-get-random-values');
+
+// Engine uses AES encryption,
+// which we shim with browserify-aes,
+// which needs cipher-base,
+// which needs stream-browserify,
+// which needs process.nextTick,
+// which is not available in React Native.
+process.nextTick = setImmediate;
+
+// Engine's getPrivateScalarFromPrivateKey uses @noble/ed25519 sha512,
+// which needs (web) crypto.subtle.digest,
+// which is not available in React Native.
+const cryptoBrowserify = require('crypto-browserify');
+global.crypto ??= {};
+global.crypto.subtle ??= {};
+global.crypto.subtle.digest ??= (algorithm, data) => {
+  const algo = algorithm.toLowerCase().replace('-', '');
+  return cryptoBrowserify.createHash(algo).update(data).digest();
+};
+
+/**
+ * Other package.json dependencies and why we need them:
+ * - assert:
+ *   - engine uses circomlibjs which uses assert
+ * - events:
+ *   - engine uses EventEmitter;
+ *   - engine uses levelup which uses EventEmitter
+ * - stream-browserify:
+ *   - engine uses AES encryption, which we shim with browserify-aes, which
+ *     needs cipher-base, which needs stream
+ */

--- a/src/services/railgun/quick-sync/graphql/index.ts
+++ b/src/services/railgun/quick-sync/graphql/index.ts
@@ -2773,8 +2773,8 @@ const importFn: ImportFn = <T>(moduleId: string) => {
       : moduleId
   )
     .split('\\')
-    .join('/')
-    .replace(`${baseDir  }/`, '');
+    .join('/');
+    // .replace(`${baseDir}/`, ''); // MODIFIED
   switch (relativeModuleId) {
     case '.graphclient/sources/goerli/introspectionSchema':
       return import('./.graphclient/sources/goerli/introspectionSchema') as T;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2766,6 +2766,16 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
 
+assert@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/assert/-/assert-2.0.0.tgz#95fc1c616d48713510680f2eaf2d10dd22e02d32"
+  integrity sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==
+  dependencies:
+    es6-object-assign "^1.1.0"
+    is-nan "^1.2.1"
+    object-is "^1.0.1"
+    util "^0.12.0"
+
 assertion-error@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
@@ -4177,6 +4187,11 @@ es6-iterator@^2.0.3:
     es5-ext "^0.10.35"
     es6-symbol "^3.1.1"
 
+es6-object-assign@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
+  integrity sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==
+
 es6-promise@^4.2.8:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
@@ -4513,6 +4528,11 @@ eventemitter3@4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.4.tgz#b5463ace635a083d018bdc7c917b4c5f10a85384"
   integrity sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==
+
+events@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
 evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   version "1.0.3"
@@ -5384,7 +5404,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -5562,6 +5582,14 @@ is-lower-case@^2.0.2:
   integrity sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==
   dependencies:
     tslib "^2.0.3"
+
+is-nan@^1.2.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/is-nan/-/is-nan-1.3.2.tgz#043a54adea31748b55b6cd4e09aadafa69bd9e1d"
+  integrity sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
 
 is-negative-zero@^2.0.2:
   version "2.0.2"
@@ -6673,6 +6701,14 @@ object-inspect@^1.12.2, object-inspect@^1.9.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
   integrity sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==
 
+object-is@^1.0.1:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.5.tgz#b9deeaa5fc7f1846a0faecdceec138e5778f53ac"
+  integrity sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+
 object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
@@ -7266,6 +7302,15 @@ readable-stream@^3.4.0, readable-stream@^3.6.0:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
+readable-stream@^3.5.0:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
+  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 readdirp@~3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
@@ -7714,6 +7759,14 @@ statuses@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
+
+stream-browserify@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-3.0.0.tgz#22b0a2850cdf6503e73085da1fc7b7d0c2122f2f"
+  integrity sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==
+  dependencies:
+    inherits "~2.0.4"
+    readable-stream "^3.5.0"
 
 streamsearch@^1.1.0:
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4606,6 +4606,11 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07"
   integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
 
+fast-base64-decode@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz#b434a0dd7d92b12b43f26819300d2dafb83ee418"
+  integrity sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==
+
 fast-decode-uri-component@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz#46f8b6c22b30ff7a81357d4f59abfae938202543"
@@ -7287,6 +7292,13 @@ react-native-fs@2.20.0:
   dependencies:
     base-64 "^0.1.0"
     utf8 "^3.0.0"
+
+react-native-get-random-values@~1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/react-native-get-random-values/-/react-native-get-random-values-1.9.0.tgz#6cb30511c406922e75fe73833dc1812a85bfb37e"
+  integrity sha512-+29IR2oxzxNVeaRwCqGZ9ABadzMI8SLTBidrIDXPOkKnm5+kEmLt34QKM4JV+d2usPErvKyS85le0OmGTHnyWQ==
+  dependencies:
+    fast-base64-decode "^1.0.0"
 
 react-native-path@0.0.5:
   version "0.0.5"


### PR DESCRIPTION
## Summary

Devs who use `@railgun-community/wallet` will be able to have a simple import command in the entry of their React Native apps:

```js
import '@railgun-community/wallet/react-native-shims';
```

Which takes care of all the shimming required.

Additionally, there is now a `postinstall` script in Wallet which checks whether we are in a RN project, and if so, will apply some patches to transitive dependencies.

Existing usage of Wallet seems to be not affected, because of the following tests:

## Tests

- [x] Works in a pure RN environment
- [x] Unit tests
- [x] Still works on web
- [x] Still works in iOS nodejs-mobile
- [x] Still works in Android nodejs-mobile
