### PR TITLE
Updates types for decompressArtifact()

### DIFF
--- a/src/services/artifacts/artifact-downloader.ts
+++ b/src/services/artifacts/artifact-downloader.ts
@@ -115,7 +115,7 @@ export class ArtifactDownloader {
   private static getArtifactData = (
     data: string | ArrayBuffer,
     artifactName: ArtifactName,
-  ): string | Buffer => {
+  ): string | Uint8Array => {
     switch (artifactName) {
       case ArtifactName.VKEY:
         return data as string;

--- a/src/services/artifacts/artifact-store.ts
+++ b/src/services/artifacts/artifact-store.ts
@@ -2,7 +2,7 @@ type GetArtifact = (path: string) => Promise<string | Buffer | null>;
 type StoreArtifact = (
   dir: string,
   path: string,
-  item: string | Buffer,
+  item: string | Uint8Array,
 ) => Promise<void>;
 type ArtifactExists = (path: string) => Promise<boolean>;
 

--- a/src/services/artifacts/artifact-util.ts
+++ b/src/services/artifacts/artifact-util.ts
@@ -59,8 +59,8 @@ export const getArtifactDownloadsPaths = (
   };
 };
 
-export const decompressArtifact = (arrayBuffer: ArrayBuffer): Buffer => {
-  const decompress = brotliDecompress as (input: Buffer) => Buffer;
+export const decompressArtifact = (arrayBuffer: ArrayBuffer): Uint8Array => {
+  const decompress = brotliDecompress as (input: Uint8Array) => Uint8Array;
   return decompress(Buffer.from(arrayBuffer));
 };
 


### PR DESCRIPTION
Seems like `brotli/decompress` is returning Uint8Array, not Buffer:

https://github.com/foliojs/brotli.js/blob/e36051345f6d27a56e5f39ea70d2f789b8574046/dec/decode.js#L580

I'm not sure if we recently updated Brotli, or what other reason this started happening recently, but it seems better to match the correct type for the decompress function.