### PR TITLE
add unloadProvider() API

### DIFF
--- a/src/services/railgun/core/providers.ts
+++ b/src/services/railgun/core/providers.ts
@@ -223,6 +223,15 @@ export const loadProvider = async (
   }
 };
 
+export const unloadProvider = async (
+  networkName: NetworkName,
+): Promise<void> => {
+  await fallbackProviderMap[networkName]?.destroy();
+  pollingProviderMap[networkName]?.destroy();
+  delete fallbackProviderMap[networkName];
+  delete pollingProviderMap[networkName];
+};
+
 export const pauseAllPollingProviders = (
   excludeNetworkName?: NetworkName,
 ): void => {


### PR DESCRIPTION
Problem: when loading providers for other networks, we don't want other network providers to remain busy with requests.

Solution: a `unloadProvider()` API that calls "destroy".