### PR TITLE
proof-of-innocence WalletPOI.init in startRailgunEngineForPOINode

### DIFF
--- a/src/services/railgun/core/init.ts
+++ b/src/services/railgun/core/init.ts
@@ -5,7 +5,6 @@ import {
   MerkletreeHistoryScanEventData,
   POIList,
   POIListType,
-  WalletScannedEventData,
   UTXOScanDecryptBalancesCompleteEventData,
   AbstractWallet,
 } from '@railgun-community/engine';
@@ -164,6 +163,8 @@ export const startRailgunEngineForPOINode = async (
   db: AbstractLevelDOWN,
   shouldDebug: boolean,
   artifactStore: ArtifactStore,
+  poiNodeURLs: string[],
+  customPOILists: POIList[],
 ): Promise<void> => {
   if (hasEngine()) {
     return;
@@ -184,6 +185,10 @@ export const startRailgunEngineForPOINode = async (
         : undefined,
     );
     setEngine(engine);
+
+    // Initialize WalletPOI with POI node interface and custom lists
+    const poiNodeInterface = new WalletPOINodeInterface(poiNodeURLs);
+    WalletPOI.init(poiNodeInterface, customPOILists ?? []);
   } catch (err) {
     throw reportAndSanitizeError(startRailgunEngineForPOINode.name, err);
   }

--- a/src/services/railgun/wallets/__tests__/wallets.test.ts
+++ b/src/services/railgun/wallets/__tests__/wallets.test.ts
@@ -61,7 +61,7 @@ describe('wallets', () => {
     const viewOnlyWallet = viewOnlyWalletForID(railgunWalletInfo.id);
     expect(viewOnlyWallet).to.not.be.undefined;
     expect(railgunWalletInfo.railgunAddress).to.equal(wallet.getAddress());
-  }).timeout(5000);
+  }).timeout(10000);
 
   it('Should get wallet address', () => {
     const addressAny = getRailgunAddress(wallet.id);


### PR DESCRIPTION
proof-of-innocence uses startRailgunEngineForPOINode, but it does not initialize WalletPOI, which engine requires in v6/v7