### PR TITLE
remove assumption that sepolia is unsupported for quicksync events

### DIFF
--- a/src/services/railgun/quick-sync/V2/quick-sync-events-graph-v2.ts
+++ b/src/services/railgun/quick-sync/V2/quick-sync-events-graph-v2.ts
@@ -28,8 +28,7 @@ const sourceNameForNetwork = (networkName: NetworkName): string => {
     case NetworkName.Ethereum:
       return 'ethereum';
     case NetworkName.EthereumSepolia:
-      // return 'sepolia';
-      throw new Error('No Graph API hosted service for Sepolia');
+      return 'sepolia';
     case NetworkName.BNBChain:
       return 'bsc';
     case NetworkName.Polygon:


### PR DESCRIPTION
Sepolia was commented out and an automatic error was thrown, assuming the graph does not support sepolia.

1. It does
2. Subsquid also supports it, which is being added in to replace the graph