### PR TITLE
fix: proper handle axios response type for artifact download

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@railgun-community/wallet",
-  "version": "10.1.1",
+  "version": "10.1.2",
   "description": "RAILGUN Wallet SDK, compatible with mobile, browser and nodejs environments.",
   "main": "dist/index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@railgun-community/shared-models": "7.3.1",
     "@whatwg-node/fetch": "^0.8.4",
     "assert": "2.0.0",
-    "axios": "0.27.2",
+    "axios": "1.7.2",
     "brotli": "^1.3.3",
     "buffer": "^6.0.3",
     "crypto-browserify": "3.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@railgun-community/wallet",
-  "version": "10.1.2",
+  "version": "10.1.1",
   "description": "RAILGUN Wallet SDK, compatible with mobile, browser and nodejs environments.",
   "main": "dist/index.js",
   "license": "MIT",

--- a/src/services/artifacts/artifact-downloader.ts
+++ b/src/services/artifacts/artifact-downloader.ts
@@ -85,6 +85,8 @@ export class ArtifactDownloader {
         dataFormatted = data;
       } else if (typeof data === 'object') {
         dataFormatted = JSON.stringify(data);
+      } else if (typeof data === 'string') {
+        dataFormatted = JSON.stringify(JSON.parse(data));
       } else {
         throw new Error('Unexpected response data type');
       }

--- a/src/services/artifacts/artifact-downloader.ts
+++ b/src/services/artifacts/artifact-downloader.ts
@@ -70,19 +70,24 @@ export class ArtifactDownloader {
     try {
       const url = getArtifactUrl(artifactName, artifactVariantString);
 
-      const result = await axios.get(url, {
+      const { data } = await axios.get<ArrayBuffer | Buffer | object>(url, {
         method: 'GET',
         responseType: ArtifactDownloader.artifactResponseType(artifactName),
       });
-      const data: ArrayBuffer | Buffer | object = result.data;
 
       // NodeJS downloads as Buffer.
       // Browser downloads as ArrayBuffer.
       // Both will validate with the same hash.
-      const dataFormatted: ArrayBuffer | Buffer | string =
-        data instanceof ArrayBuffer || data instanceof Buffer
-          ? data
-          : JSON.stringify(data);
+
+      let dataFormatted: ArrayBuffer | Buffer | string;
+
+      if (data instanceof ArrayBuffer || data instanceof Buffer) {
+        dataFormatted = data;
+      } else if (typeof data === 'object') {
+        dataFormatted = JSON.stringify(data);
+      } else {
+        throw new Error('Unexpected response data type');
+      }
 
       const decompressedData = ArtifactDownloader.getArtifactData(
         dataFormatted,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3032,13 +3032,14 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@0.27.2:
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
-  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+axios@1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.2.tgz#b625db8a7051fbea61c35a3cbb3a1daa7b9c7621"
+  integrity sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==
   dependencies:
-    follow-redirects "^1.14.9"
+    follow-redirects "^1.15.6"
     form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 b4a@^1.0.1:
   version "1.6.0"
@@ -5123,7 +5124,7 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
-follow-redirects@^1.14.9:
+follow-redirects@^1.15.6:
   version "1.15.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
   integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
@@ -7565,6 +7566,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.28:
   version "1.9.0"


### PR DESCRIPTION
With Axios 1.7.2 version, the response artifacts were mistakenly being handled and in some cases being double parsed, but still being evaluated as valid through the code, causing unwanted side effects (Prover not processing this right). 

This fixes the response parsing issue. 