### PR TITLE
fix: make assertContiguousCommitmentEvents comprehend possible tree rollovers

### DIFF
--- a/src/services/railgun/quick-sync/V2/__tests__/quick-sync-events-graph-v2.test.ts
+++ b/src/services/railgun/quick-sync/V2/__tests__/quick-sync-events-graph-v2.test.ts
@@ -43,6 +43,7 @@ const assertContiguousCommitmentEvents = (
   // Track unique events by their actual start positions
   const positionMap = new Map<number, Set<number>>();
 
+  // Build map of positions to their commitment indices
   for (const event of commitmentEvents) {
     const uniqueIndices = new Set(event.commitments.map(c => c.utxoIndex));
     positionMap.set(event.startPosition, uniqueIndices);

--- a/src/services/railgun/quick-sync/V2/__tests__/quick-sync-events-graph-v2.test.ts
+++ b/src/services/railgun/quick-sync/V2/__tests__/quick-sync-events-graph-v2.test.ts
@@ -42,18 +42,15 @@ const assertContiguousCommitmentEvents = (
 ) => {
   // Track unique events by their actual start positions
   const positionMap = new Map<number, Set<number>>();
-  
-  // First, log what we're processing
+
   for (const event of commitmentEvents) {
     const uniqueIndices = new Set(event.commitments.map(c => c.utxoIndex));
-    // Store unique indices for this position
     positionMap.set(event.startPosition, uniqueIndices);
   }
 
   // Get sorted positions
   const positions = Array.from(positionMap.keys()).sort((a, b) => a - b);
 
-  // Validate sequence
   // eslint-disable-next-line no-plusplus
   for (let i = 0; i < positions.length - 1; i++) {
     const currentPos = positions[i];


### PR DESCRIPTION
Previous version of `assertContiguousCommitmentEvents` did not include logic for a possible tree rollover, this fix was already introduced in engine previously: https://github.com/Railgun-Community/engine/commit/bb52002209deefcc233e6e5ea09d9a5f6281dab3#diff-4bdbc1d9079555ae4e1178a2910b8f846950e27b2b81897d5fc3aafeddd10ab8R240, but it was missing this complementary test code for wallet.


Just to preview what the look of the issue

![image](https://github.com/user-attachments/assets/0dd6b099-ea64-4fe2-bf2d-207b84e1ed6f)

The test was prev failing bc it had a gap in the sequence between 3 and 5 (if you notice, 4 is missing). This tackles that case. 