### PR TITLE
fix: replace faulty provider with more reliable one

### DIFF
--- a/src/tests/mocks.test.ts
+++ b/src/tests/mocks.test.ts
@@ -243,7 +243,7 @@ export const MOCK_FALLBACK_PROVIDER_JSON_CONFIG_SEPOLIA: FallbackProviderJsonCon
     chainId: 11155111,
     providers: [
       {
-        provider: 'https://rpc.sepolia.org/',
+        provider: 'https://sepolia.drpc.org',
         priority: 3,
         weight: 3,
         maxLogsPerBatch: 2,


### PR DESCRIPTION
## Replace test fallback provider url

### What
improves the reliability of our test suite by using a more stable RPC endpoint for the Sepolia testnet.

### How
fixed failing provider tests by replacing an unreliable Sepolia RPC endpoint with a more stable one. The previous endpoint (`https://rpc.sepolia.org/`) was causing quorum issues and failing to return block numbers consistently. 

### Changes made:
- Replaced the primary Sepolia RPC provider with `https://sepolia.drpc.org`
- Tests now pass consistently without quorum errors
