### PR TITLE
fix: update proof transaction generation to handle sendWithPublicWall…

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@graphql-mesh/types": "^0.91.14",
     "@graphql-mesh/utils": "^0.43.22",
     "@noble/ed25519": "^1.7.1",
-    "@railgun-community/engine": "9.3.1",
+    "@railgun-community/engine": "9.4.0",
     "@railgun-community/shared-models": "7.5.0",
     "@whatwg-node/fetch": "^0.8.4",
     "assert": "2.0.0",

--- a/src/services/transactions/tx-generator.ts
+++ b/src/services/transactions/tx-generator.ts
@@ -134,9 +134,9 @@ export const generateDummyProofTransactions = async (
   const broadcasterFeeERC20AmountRecipient: Optional<RailgunERC20AmountRecipient> =
     broadcasterFeeERC20Amount
       ? {
-          ...broadcasterFeeERC20Amount,
-          recipientAddress: broadcasterRailgunAddress,
-        }
+        ...broadcasterFeeERC20Amount,
+        recipientAddress: broadcasterRailgunAddress,
+      }
       : undefined;
 
   return (
@@ -202,6 +202,7 @@ export const generateUnshieldBaseToken = async (
       txs,
       toWalletAddress,
       relayAdaptParamsRandom,
+      useDummyProof,
     );
   if (useDummyProof) {
     return {

--- a/src/services/transactions/tx-proof-unshield.ts
+++ b/src/services/transactions/tx-proof-unshield.ts
@@ -222,6 +222,7 @@ export const generateUnshieldBaseTokenProof = async (
         dummyTxs,
         publicWalletAddress,
         relayAdaptParamsRandom,
+        sendWithPublicWallet,
       );
     const relayAdaptContract =
       RelayAdaptVersionedSmartContracts.getRelayAdaptContract(
@@ -262,7 +263,7 @@ export const generateUnshieldBaseTokenProof = async (
       networkName,
       publicWalletAddress,
       relayAdaptParamsRandom,
-      false, // useDummyProof
+      sendWithPublicWallet, // useDummyProof
     );
 
     const nullifiers = nullifiersForTransactions(provedTransactions);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1949,10 +1949,10 @@
   resolved "https://registry.yarnpkg.com/@railgun-community/curve25519-scalarmult-wasm/-/curve25519-scalarmult-wasm-0.1.5.tgz#edb5e40a8f1fdb7f7e0de1d04e8badabe41cb2a8"
   integrity sha512-Cur8uM/IdNW3WzUwdPloDG1CF0rpSBDWq2yGXJMZ7IMeBGdc4Jj0h9tnNMFRZ35ZuCVVbZ3yClmqSa4PsbpdGQ==
 
-"@railgun-community/engine@9.3.1":
-  version "9.3.1"
-  resolved "https://registry.yarnpkg.com/@railgun-community/engine/-/engine-9.3.1.tgz#cfc14b6a7dd7d4c841e0fbe91ccf417e71414424"
-  integrity sha512-fTN/Ct+myrcecBZOlk8+pEdNZI0gy3s9aGeu54YKAn1TAMORH9udu9dQ3UFEkXS9P+EdcABSpbxPp/KIrp+N6Q==
+"@railgun-community/engine@9.4.0":
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/@railgun-community/engine/-/engine-9.4.0.tgz#d8beb18ac83f2a560ce63f8b5e49e3f0866a2a5a"
+  integrity sha512-7BZcUKo5oVBWdyBrjpKft3zT0hFo1V3PzcDSuvEIDzA8mOqFXTrIr4j+0A9ONwb5bo4A/7vfO0yll6uk0Y4GSQ==
   dependencies:
     "@noble/ciphers" "^0.4.0"
     "@noble/ed25519" "^1.7.1"


### PR DESCRIPTION
### Enhancements to transaction proof generation:
* Added a new parameter, `useDummyProof`, to the `generateUnshieldBaseToken` function in `src/services/transactions/tx-generator.ts`
* Replaced the hardcoded `false` value with the `sendWithPublicWallet` parameter for the `useDummyProof` argument in the `generateUnshieldBaseTokenProof` function in `src/services/transactions/tx-proof-unshield.ts`.
