### PR TITLE
Fix UnshieldBaseToken proof caching error

### DIFF
--- a/src/services/transactions/tx-proof-unshield.ts
+++ b/src/services/transactions/tx-proof-unshield.ts
@@ -262,8 +262,7 @@ export const generateUnshieldBaseTokenProof = async (
       provedTransactions,
       networkName,
       publicWalletAddress,
-      relayAdaptParamsRandom,
-      sendWithPublicWallet, // useDummyProof
+      relayAdaptParamsRandom
     );
 
     const nullifiers = nullifiersForTransactions(provedTransactions);


### PR DESCRIPTION
### What 

`generateUnshieldBaseToken` was incorrectly using sendWithPublicWallet as the useDummyProof parameter, causing transactions with public wallets to add a `from` address. This prevented proof caching since `setCachedProvedTransaction` explicitly rejects transactions with a from field.

### Solution 

Reverted useDummyProof parameter back to false (default) to maintain consistency with other proof types and enable proper transaction caching.