### PR TITLE
fix: update GitHub Actions to use latest versions and improve publish…

### DIFF
--- a/.github/workflows/publish-npmjs.yml
+++ b/.github/workflows/publish-npmjs.yml
@@ -10,17 +10,18 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
+    environment: npm-release
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
-          node-version: '16.x'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - name: Install yarn
         uses: borales/actions-yarn@v4
         with:
           cmd: install
-      - run: yarn publish --access public
+      - run: yarn publish

--- a/package.json
+++ b/package.json
@@ -30,6 +30,14 @@
     "build-graphql-V3": "rm -rf src/services/railgun/quick-sync/V3/graphql/.graphclient && graphclient build --dir src/services/railgun/quick-sync/V3/graphql",
     "build-graphql-railgun-txids": "rm -rf src/services/railgun/railgun-txids/graphql/.graphclient && graphclient build --dir src/services/railgun/railgun-txids/graphql"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Railgun-Community/wallet.git"
+  },
+  "homepage": "https://github.com/Railgun-Community/wallet#readme",
+  "bugs": {
+    "url": "https://github.com/Railgun-Community/wallet/issues"
+  },
   "dependencies": {
     "@graphql-mesh/cache-localforage": "^0.7.20",
     "@graphql-mesh/cross-helpers": "^0.3.4",


### PR DESCRIPTION
This pull request updates the `.github/workflows/publish-npmjs.yml` workflow to modernize the publishing process and ensure compatibility with the latest tools and environments. The most important changes are grouped below:

Workflow modernization:

* Updated the workflow job name from `build` to `publish` and set the environment to `npm-release` for clearer intent and improved security.

Dependency updates:

* Upgraded the `actions/checkout` and `actions/setup-node` actions from version 3 to version 6, and updated the Node.js version from `16.x` to `24` to use the latest features and ensure compatibility.

Publishing command adjustment:

* Changed the `yarn publish` command by removing the `--access public` flag, simplifying the publishing process.