### PR TITLE
fix: add networkName parameter to getTokenOwnerWithFallback

### DIFF
--- a/src/services/transactions/tx-unshield.ts
+++ b/src/services/transactions/tx-unshield.ts
@@ -302,7 +302,8 @@ async function extractTokenOwnerFromTransferEvents(
 async function getTokenOwnerWithFallback(
   receipt: TransactionReceipt,
   transaction: TransactionResponse,
-  railgunContractAddress: string
+  railgunContractAddress: string,
+  networkName: NetworkName
 ): Promise<string> {
   try {
     // first attempt is try to extract from Transfer events
@@ -310,6 +311,17 @@ async function getTokenOwnerWithFallback(
       receipt,
       railgunContractAddress
     );
+
+    const normalizedTokenOwner = tokenOwner.toLowerCase()
+    const normalizedRelayAdaptAddresses = [
+      NETWORK_CONFIG[networkName].relayAdaptContract.toLowerCase(),
+      ...NETWORK_CONFIG[networkName].relayAdaptHistory.map(a=>a.toLowerCase())
+    ]
+
+    if(normalizedRelayAdaptAddresses.includes(normalizedTokenOwner)){
+      return transaction.from;
+    }
+
     return tokenOwner;
   } catch (error) {
     return transaction.from;
@@ -359,7 +371,8 @@ export const getERC20AndNFTAmountRecipientsForUnshieldToOrigin = async (
   const recipientAddress = await getTokenOwnerWithFallback(
     receipt,
     transaction,
-    railgunContractAddress
+    railgunContractAddress,
+    networkName
   );
   const erc20Amounts = getSerializedERC20Balances(balances);
   const nftAmounts = getSerializedNFTBalances(balances);


### PR DESCRIPTION
This pull request updates the logic for determining the token owner in unshield transactions, particularly to handle cases where the token owner is a Relay Adapt contract. The main improvement is that if the token owner is detected as a Relay Adapt contract (current or historical), the function now correctly assigns the transaction's sender as the owner.

Key changes:

**Token owner extraction logic:**

* Updated `getTokenOwnerWithFallback` to accept a `networkName` parameter and use it to check if the extracted token owner is a current or historical Relay Adapt contract address. If so, it returns the transaction sender as the owner instead.

**Function call updates:**

* Modified the call to `getTokenOwnerWithFallback` in `getERC20AndNFTAmountRecipientsForUnshieldToOrigin` to pass the `networkName` argument, ensuring the updated logic is used.