### PR TITLE
ci: remove third-party borales/actions-yarn from workflows

### DIFF
--- a/.github/workflows/publish-npmjs.yml
+++ b/.github/workflows/publish-npmjs.yml
@@ -20,8 +20,7 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-      - name: Install yarn
-        uses: borales/actions-yarn@v4
-        with:
-          cmd: install
+          cache: 'yarn'
+      - run: corepack enable
+      - run: yarn install --frozen-lockfile
       - run: npm publish

--- a/.github/workflows/unit-tests-V2.yml
+++ b/.github/workflows/unit-tests-V2.yml
@@ -16,10 +16,8 @@ jobs:
         with:
           node-version: '16'
           cache: 'yarn'
-      - name: Install yarn
-        uses: borales/actions-yarn@v4
-        with:
-          cmd: install
+      - run: corepack enable
+      - run: yarn install --frozen-lockfile
       - name: Yarn test
         shell: bash
         run: yarn test-V2

--- a/.github/workflows/unit-tests-V3.yml
+++ b/.github/workflows/unit-tests-V3.yml
@@ -17,10 +17,8 @@ jobs:
         with:
           node-version: '16'
           cache: 'yarn'
-      - name: Install yarn
-        uses: borales/actions-yarn@v4
-        with:
-          cmd: install
+      - run: corepack enable
+      - run: yarn install --frozen-lockfile
       - name: Yarn test
         shell: bash
         run: yarn test


### PR DESCRIPTION
## What

Removes `borales/actions-yarn@v4` from all three workflow files (`publish-npmjs.yml`, `unit-tests-V2.yml`, `unit-tests-V3.yml`). Replaces it with `corepack enable` + `yarn install --frozen-lockfile`, using `actions/setup-node`'s built-in yarn cache. `corepack` reads `packageManager` (`yarn@1.22.22`) from `package.json` and installs that exact yarn version.

## Why

Third-party GitHub Actions run inside our workflow with full access to job secrets and tokens. In `publish-npmjs.yml` that includes the npm OIDC publish token; in the unit-test workflows it includes any secret exposed to the runner. Each external action is an item on our supply-chain attack surface — a compromise or malicious update silently inherits those permissions. `corepack` ships with Node.js and does what this action did, with no third-party dependency.

## CI note

The `🧪 Test` job intermittently fails on this branch due to **external GraphQL endpoint 502s** in `quick-sync-events-graph-v2` and `railgun-txid-sync-graph` tests — the rest of the suite passes. This flake exists on `main` independently and is not caused by this PR (the test makes live calls to a hosted Graph service that 502s periodically). Re-running usually clears it.