### PR TITLE
Zy0n/7702 base main

### DIFF
--- a/src/services/poi/poi-validation.ts
+++ b/src/services/poi/poi-validation.ts
@@ -26,6 +26,7 @@ export class POIValidator {
     transactionRequest: ContractTransaction,
     useRelayAdapt: boolean,
     pois: PreTransactionPOIsPerTxidLeafPerList,
+    useRelayAdapt7702 = false,
   ): Promise<{
     isValid: boolean;
     error?: string;
@@ -41,6 +42,7 @@ export class POIValidator {
       contractAddress = RailgunVersionedSmartContracts.getRelayAdaptContract(
         txidVersion,
         chain,
+        useRelayAdapt7702,
       ).address;
     } else {
       contractAddress = RailgunVersionedSmartContracts.getVerifier(
@@ -57,6 +59,7 @@ export class POIValidator {
       transactionRequest,
       useRelayAdapt,
       pois,
+      useRelayAdapt7702,
     );
   }
 

--- a/src/services/railgun/core/load-provider.ts
+++ b/src/services/railgun/core/load-provider.ts
@@ -93,6 +93,9 @@ const loadProviderForNetwork = async (
     publicName,
     poi,
     supportsV3,
+    supports7702,
+    relayAdapt7702Contract,
+    railgunRegistryContract
   } = network;
   if (!proxyContract) {
     throw new Error(`Could not find Proxy contract for network: ${publicName}`);
@@ -116,6 +119,13 @@ const loadProviderForNetwork = async (
       deploymentBlockPoseidonMerkleAccumulatorV3 ?? 0,
   };
 
+  // load 7702 contracts only if supported.
+  let adapt7702Contract; let railgunRegistry;
+  if(supports7702){
+    adapt7702Contract = isDefined(relayAdapt7702Contract) && relayAdapt7702Contract !== '' ? relayAdapt7702Contract : undefined;
+    railgunRegistry = isDefined(railgunRegistryContract) && railgunRegistryContract !== '' ? railgunRegistryContract : undefined;
+  }
+
   // This function will set up the contracts for this chain.
   // Throws if provider does not respond.
   await engine.loadNetwork(
@@ -130,6 +140,8 @@ const loadProviderForNetwork = async (
     deploymentBlocks,
     poi?.launchBlock,
     supportsV3,
+    adapt7702Contract,
+    railgunRegistry
   );
 };
 
@@ -140,7 +152,7 @@ const loadProviderForNetwork = async (
 export const loadProvider = async (
   fallbackProviderJsonConfig: FallbackProviderJsonConfig,
   networkName: NetworkName,
-  pollingInterval = 15000,
+  pollingInterval = 60000,
 ): Promise<LoadProviderResponse> => {
   try {
     delete fallbackProviderMap[networkName];

--- a/src/services/railgun/core/load-provider.ts
+++ b/src/services/railgun/core/load-provider.ts
@@ -18,6 +18,7 @@ import {
   createPollingJsonRpcProviderForListeners,
 } from '@railgun-community/engine';
 import { FallbackProvider } from 'ethers'
+import { getRelayAdapt7702ExecutionTypeForNetwork } from '../wallets/relay-adapt-7702-execution';
 import {
   fallbackProviderMap,
   pollingProviderMap,
@@ -120,10 +121,13 @@ const loadProviderForNetwork = async (
   };
 
   // load 7702 contracts only if supported.
-  let adapt7702Contract; let railgunRegistry;
+  let adapt7702Contract; let railgunRegistry; let relayAdapt7702ExecutionType;
   if(supports7702){
     adapt7702Contract = isDefined(relayAdapt7702Contract) && relayAdapt7702Contract !== '' ? relayAdapt7702Contract : undefined;
     railgunRegistry = isDefined(railgunRegistryContract) && railgunRegistryContract !== '' ? railgunRegistryContract : undefined;
+    relayAdapt7702ExecutionType = isDefined(adapt7702Contract)
+      ? getRelayAdapt7702ExecutionTypeForNetwork(networkName)
+      : undefined;
   }
 
   // This function will set up the contracts for this chain.
@@ -141,7 +145,8 @@ const loadProviderForNetwork = async (
     poi?.launchBlock,
     supportsV3,
     adapt7702Contract,
-    railgunRegistry
+    railgunRegistry,
+    relayAdapt7702ExecutionType,
   );
 };
 

--- a/src/services/railgun/process/extract-transaction-data.ts
+++ b/src/services/railgun/process/extract-transaction-data.ts
@@ -9,6 +9,7 @@ export const extractFirstNoteERC20AmountMapFromTransactionRequest = (
   network: Network,
   transactionRequest: ContractTransaction,
   useRelayAdapt: boolean,
+  useRelayAdapt7702 = false,
 ): Promise<MapType<bigint>> => {
   const chain = network.chain;
 
@@ -17,6 +18,7 @@ export const extractFirstNoteERC20AmountMapFromTransactionRequest = (
     contractAddress = RailgunVersionedSmartContracts.getRelayAdaptContract(
       txidVersion,
       chain,
+      useRelayAdapt7702,
     ).address;
   } else {
     contractAddress = RailgunVersionedSmartContracts.getVerifier(
@@ -32,5 +34,6 @@ export const extractFirstNoteERC20AmountMapFromTransactionRequest = (
     transactionRequest,
     useRelayAdapt,
     contractAddress,
+    useRelayAdapt7702,
   );
 };

--- a/src/services/railgun/wallets/__tests__/ephemeral-key-manager.test.ts
+++ b/src/services/railgun/wallets/__tests__/ephemeral-key-manager.test.ts
@@ -1,0 +1,124 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import Sinon, { SinonStub } from 'sinon';
+import { RailgunWallet } from '@railgun-community/engine';
+import { EphemeralKeyManager } from '../ephemeral-key-manager';
+import { HDNodeWallet } from 'ethers';
+import { Chain, ChainType } from '@railgun-community/shared-models';
+
+chai.use(chaiAsPromised);
+const { expect } = chai;
+
+const MOCK_ENCRYPTION_KEY = '0x1234';
+const MOCK_MNEMONIC = 'test test test test test test test test test test test junk';
+const MOCK_CHAIN: Chain = { type: ChainType.EVM, id: 1 };
+
+describe('ephemeral-key-manager', () => {
+  let getEphemeralWalletStub: SinonStub;
+  let getEphemeralKeyIndexStub: SinonStub;
+  let setEphemeralKeyIndexStub: SinonStub;
+  let getTransactionHistoryStub: SinonStub;
+  let manager: EphemeralKeyManager;
+
+  beforeEach(() => {
+    const railgunWallet = {
+      getEphemeralWallet: async () => {},
+      getEphemeralKeyIndex: async () => {},
+      setEphemeralKeyIndex: async () => {},
+      getTransactionHistory: async () => {},
+    } as unknown as RailgunWallet;
+
+    getEphemeralWalletStub = Sinon.stub(railgunWallet, 'getEphemeralWallet');
+    getEphemeralKeyIndexStub = Sinon.stub(railgunWallet, 'getEphemeralKeyIndex');
+    setEphemeralKeyIndexStub = Sinon.stub(railgunWallet, 'setEphemeralKeyIndex');
+    getTransactionHistoryStub = Sinon.stub(railgunWallet, 'getTransactionHistory');
+
+    manager = new EphemeralKeyManager(railgunWallet, MOCK_ENCRYPTION_KEY);
+  });
+
+  it('Should get account at index', async () => {
+    const mockWallet = HDNodeWallet.fromPhrase(MOCK_MNEMONIC);
+    getEphemeralWalletStub.resolves(mockWallet);
+
+    const account = await manager.getAccount(BigInt(MOCK_CHAIN.id), 0);
+    expect(account.address).to.equal(mockWallet.address);
+    expect(getEphemeralWalletStub.calledWith(MOCK_ENCRYPTION_KEY, BigInt(MOCK_CHAIN.id), 0)).to.be.true;
+  });
+
+  it('Should get current account', async () => {
+    const mockWallet = HDNodeWallet.fromPhrase(MOCK_MNEMONIC);
+    getEphemeralKeyIndexStub.resolves(5);
+    getEphemeralWalletStub.resolves(mockWallet);
+
+    const account = await manager.getCurrentAccount(BigInt(MOCK_CHAIN.id));
+    expect(account.address).to.equal(mockWallet.address);
+    expect(getEphemeralKeyIndexStub.calledWith(BigInt(MOCK_CHAIN.id))).to.be.true;
+    expect(getEphemeralWalletStub.calledWith(MOCK_ENCRYPTION_KEY, BigInt(MOCK_CHAIN.id), 5)).to.be.true;
+  });
+
+  it('Should get next account and increment index', async () => {
+    const mockWallet = HDNodeWallet.fromPhrase(MOCK_MNEMONIC);
+    getEphemeralKeyIndexStub.resolves(5);
+    getEphemeralWalletStub.resolves(mockWallet);
+    setEphemeralKeyIndexStub.resolves();
+
+    const account = await manager.getNextAccount(BigInt(MOCK_CHAIN.id));
+    expect(account.address).to.equal(mockWallet.address);
+    expect(getEphemeralKeyIndexStub.calledWith(BigInt(MOCK_CHAIN.id))).to.be.true;
+    expect(setEphemeralKeyIndexStub.calledWith(BigInt(MOCK_CHAIN.id), 6)).to.be.true;
+    expect(getEphemeralWalletStub.calledWith(MOCK_ENCRYPTION_KEY, BigInt(MOCK_CHAIN.id), 6)).to.be.true;
+  });
+
+  it('Should scan history and recover index', async () => {
+    const mockWallet0 = HDNodeWallet.fromPhrase(MOCK_MNEMONIC, undefined, "m/44'/60'/0'/7702/1'/0");
+    const mockWallet1 = HDNodeWallet.fromPhrase(MOCK_MNEMONIC, undefined, "m/44'/60'/0'/7702/1'/1");
+    const mockWallet2 = HDNodeWallet.fromPhrase(MOCK_MNEMONIC, undefined, "m/44'/60'/0'/7702/1'/2");
+
+    getEphemeralWalletStub.withArgs(MOCK_ENCRYPTION_KEY, BigInt(MOCK_CHAIN.id), 0).resolves(mockWallet0);
+    getEphemeralWalletStub.withArgs(MOCK_ENCRYPTION_KEY, BigInt(MOCK_CHAIN.id), 1).resolves(mockWallet1);
+    getEphemeralWalletStub.withArgs(MOCK_ENCRYPTION_KEY, BigInt(MOCK_CHAIN.id), 2).resolves(mockWallet2);
+    // Default resolve for other calls (like gap scanning)
+    getEphemeralWalletStub.resolves(mockWallet2);
+
+    // Mock history with unshield to index 1
+    getTransactionHistoryStub.resolves([
+      {
+        unshieldTokenAmounts: [
+          { recipientAddress: mockWallet1.address },
+        ],
+      },
+    ]);
+
+    getEphemeralKeyIndexStub.resolves(0); // Stored index is 0 (outdated)
+    setEphemeralKeyIndexStub.resolves();
+
+    const recoveredIndex = await manager.scanHistoryForEphemeralIndex(MOCK_CHAIN);
+
+    expect(recoveredIndex).to.equal(2); // Should be index 1 + 1
+    expect(setEphemeralKeyIndexStub.calledWith(BigInt(MOCK_CHAIN.id), 2)).to.be.true;
+  });
+
+  it('Should not update index if stored is higher', async () => {
+    const mockWallet0 = HDNodeWallet.fromPhrase(MOCK_MNEMONIC, undefined, "m/44'/60'/0'/7702/1'/0");
+    const mockWalletRandom = HDNodeWallet.createRandom();
+    
+    getEphemeralWalletStub.resolves(mockWalletRandom); // Default for non-matching indices
+    getEphemeralWalletStub.withArgs(MOCK_ENCRYPTION_KEY, BigInt(MOCK_CHAIN.id), 0).resolves(mockWallet0);
+
+    getTransactionHistoryStub.resolves([
+      {
+        unshieldTokenAmounts: [
+          { recipientAddress: mockWallet0.address },
+        ],
+      },
+    ]);
+
+    getEphemeralKeyIndexStub.resolves(5); // Stored index is 5 (higher)
+    setEphemeralKeyIndexStub.resolves();
+
+    const recoveredIndex = await manager.scanHistoryForEphemeralIndex(MOCK_CHAIN);
+
+    expect(recoveredIndex).to.equal(1); // Found index 0 + 1 = 1
+    expect(setEphemeralKeyIndexStub.called).to.be.false; // Should not update
+  });
+});

--- a/src/services/railgun/wallets/__tests__/relay-adapt-7702-execution.test.ts
+++ b/src/services/railgun/wallets/__tests__/relay-adapt-7702-execution.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { Interface, Provider } from 'ethers';
 import {
   ABIRelayAdapt7702,
-  ABIRelayAdapt7702_Legacy_PreExecuteNonce,
+  ABIRelayAdapt7702_Legacy_PreExecuteNonce as abiRelayAdapt7702LegacyPreExecuteNonce,
   RelayAdapt7702,
   RelayAdapt7702ExecutionType,
 } from '@railgun-community/engine';
@@ -133,7 +133,7 @@ describe('relay-adapt-7702-execution', () => {
     const data = encodeRelayAdapt7702Execute([], actionData, signature, {
       executionType: RelayAdapt7702ExecutionType.LegacyPreExecuteNonce,
     });
-    const parsed = new Interface(ABIRelayAdapt7702_Legacy_PreExecuteNonce).parseTransaction({ data });
+    const parsed = new Interface(abiRelayAdapt7702LegacyPreExecuteNonce).parseTransaction({ data });
 
     expect(parsed?.name).to.equal('execute');
     expect(parsed?.args[2]).to.equal(signature);

--- a/src/services/railgun/wallets/__tests__/relay-adapt-7702-execution.test.ts
+++ b/src/services/railgun/wallets/__tests__/relay-adapt-7702-execution.test.ts
@@ -1,10 +1,11 @@
 import { expect } from 'chai';
-import { Interface, Provider } from 'ethers';
+import { Interface, Provider, Wallet, verifyTypedData } from 'ethers';
 import {
   ABIRelayAdapt7702,
   ABIRelayAdapt7702_Legacy_PreExecuteNonce as abiRelayAdapt7702LegacyPreExecuteNonce,
   RelayAdapt7702,
   RelayAdapt7702ExecutionType,
+  RelayAdapt7702Helper,
 } from '@railgun-community/engine';
 import {
   encodeRelayAdapt7702Execute,
@@ -137,5 +138,68 @@ describe('relay-adapt-7702-execution', () => {
 
     expect(parsed?.name).to.equal('execute');
     expect(parsed?.args[2]).to.equal(signature);
+  });
+
+  // Binding guard: the execute nonce that is SIGNED must equal the one that is ENCODED, at a
+  // nonce > 0 (the production steady state — the ephemeral account is reused). The existing
+  // encode test only checks the encoded side; a regression that signed one nonce and encoded
+  // another would revert on-chain (signature recovers to the wrong address) yet still pass an
+  // encode-only assertion. This drives the real sign + encode primitives with one shared
+  // executionDetails and proves they agree — and that the agreement is nonce-sensitive.
+  it('binds the signed execute nonce to the encoded calldata nonce (nonce > 0)', async () => {
+    const signer = Wallet.createRandom();
+    const chainId = 1n;
+    const executeNonce = 7n;
+    const executionDetails = {
+      executionType: RelayAdapt7702ExecutionType.ExecuteWithNonce,
+      executeNonce,
+    };
+
+    const executionSignature = await RelayAdapt7702Helper.signExecutionAuthorization(
+      signer,
+      [],
+      actionData,
+      chainId,
+      executionDetails,
+    );
+
+    // Encode with the SAME executionDetails object the signature was produced from.
+    const data = encodeRelayAdapt7702Execute([], actionData, executionSignature, executionDetails);
+    const parsed = new Interface(ABIRelayAdapt7702).parseTransaction({ data });
+    expect(parsed?.args[2]).to.equal(executeNonce); // encoded nonce == 7
+
+    const domain = {
+      name: 'RelayAdapt7702',
+      version: '1',
+      chainId,
+      verifyingContract: signer.address,
+    };
+    const types = { Execute: [{ name: 'payloadHash', type: 'bytes32' }] };
+
+    // Recovering over the nonce-7 payload returns the signer -> it was SIGNED over nonce 7.
+    expect(
+      verifyTypedData(
+        domain,
+        types,
+        { payloadHash: RelayAdapt7702Helper.getExecutePayloadHash([], actionData, executionDetails) },
+        executionSignature,
+      ),
+    ).to.equal(signer.address);
+
+    // ...and the binding is nonce-sensitive: recovering over nonce 0 must NOT match, so a
+    // sign-0/encode-7 divergence would be caught (on-chain it would revert).
+    expect(
+      verifyTypedData(
+        domain,
+        types,
+        {
+          payloadHash: RelayAdapt7702Helper.getExecutePayloadHash([], actionData, {
+            executionType: RelayAdapt7702ExecutionType.ExecuteWithNonce,
+            executeNonce: 0n,
+          }),
+        },
+        executionSignature,
+      ),
+    ).to.not.equal(signer.address);
   });
 });

--- a/src/services/railgun/wallets/__tests__/relay-adapt-7702-execution.test.ts
+++ b/src/services/railgun/wallets/__tests__/relay-adapt-7702-execution.test.ts
@@ -1,0 +1,40 @@
+import { expect } from 'chai';
+import { Interface } from 'ethers';
+import {
+  ABIRelayAdapt7702,
+  ABIRelayAdapt7702_Legacy_PreExecuteNonce,
+  RelayAdapt7702,
+  RelayAdapt7702ExecutionType,
+} from '@railgun-community/engine';
+import { encodeRelayAdapt7702Execute } from '../relay-adapt-7702-execution';
+
+describe('relay-adapt-7702-execution', () => {
+  const actionData: RelayAdapt7702.ActionDataStruct = {
+    requireSuccess: true,
+    minGasLimit: 0n,
+    calls: [],
+  };
+  const signature = '0x1234';
+
+  it('should encode current nonce-aware execute calldata', () => {
+    const data = encodeRelayAdapt7702Execute([], actionData, signature, {
+      executionType: RelayAdapt7702ExecutionType.ExecuteWithNonce,
+      executeNonce: 7n,
+    });
+    const parsed = new Interface(ABIRelayAdapt7702).parseTransaction({ data });
+
+    expect(parsed?.name).to.equal('execute');
+    expect(parsed?.args[2]).to.equal(7n);
+    expect(parsed?.args[3]).to.equal(signature);
+  });
+
+  it('should encode legacy pre-execute-nonce calldata', () => {
+    const data = encodeRelayAdapt7702Execute([], actionData, signature, {
+      executionType: RelayAdapt7702ExecutionType.LegacyPreExecuteNonce,
+    });
+    const parsed = new Interface(ABIRelayAdapt7702_Legacy_PreExecuteNonce).parseTransaction({ data });
+
+    expect(parsed?.name).to.equal('execute');
+    expect(parsed?.args[2]).to.equal(signature);
+  });
+});

--- a/src/services/railgun/wallets/__tests__/relay-adapt-7702-execution.test.ts
+++ b/src/services/railgun/wallets/__tests__/relay-adapt-7702-execution.test.ts
@@ -1,12 +1,15 @@
 import { expect } from 'chai';
-import { Interface } from 'ethers';
+import { Interface, Provider } from 'ethers';
 import {
   ABIRelayAdapt7702,
   ABIRelayAdapt7702_Legacy_PreExecuteNonce,
   RelayAdapt7702,
   RelayAdapt7702ExecutionType,
 } from '@railgun-community/engine';
-import { encodeRelayAdapt7702Execute } from '../relay-adapt-7702-execution';
+import {
+  encodeRelayAdapt7702Execute,
+  getRelayAdapt7702ExecuteNonce,
+} from '../relay-adapt-7702-execution';
 
 describe('relay-adapt-7702-execution', () => {
   const actionData: RelayAdapt7702.ActionDataStruct = {
@@ -15,6 +18,104 @@ describe('relay-adapt-7702-execution', () => {
     calls: [],
   };
   const signature = '0x1234';
+  const ephemeralAddress = '0x0000000000000000000000000000000000000001';
+
+  const createProvider = (
+    getCode: () => Promise<string>,
+    call?: () => Promise<string>,
+  ): Provider => ({
+    getCode,
+    call,
+  } as unknown as Provider);
+
+  it('should return undefined nonce for legacy pre-execute-nonce execution', async () => {
+    const provider = createProvider(async () => {
+      throw new Error('getCode should not be called');
+    });
+
+    const nonce = await getRelayAdapt7702ExecuteNonce(
+      provider,
+      ephemeralAddress,
+      RelayAdapt7702ExecutionType.LegacyPreExecuteNonce,
+    );
+
+    expect(nonce).to.be.undefined;
+  });
+
+  it('should return on-chain execute nonce when nonce call succeeds', async () => {
+    const iface = new Interface(ABIRelayAdapt7702);
+    const provider = createProvider(
+      async () => '0x7702',
+      async () => iface.encodeFunctionResult('nonce', [7n]),
+    );
+
+    const nonce = await getRelayAdapt7702ExecuteNonce(
+      provider,
+      ephemeralAddress,
+      RelayAdapt7702ExecutionType.ExecuteWithNonce,
+    );
+
+    expect(nonce).to.equal(7n);
+  });
+
+  it('should return zero nonce for fresh no-code ephemeral account', async () => {
+    const provider = createProvider(
+      async () => '0x',
+      async () => {
+        throw new Error('nonce should not be called');
+      },
+    );
+
+    const nonce = await getRelayAdapt7702ExecuteNonce(
+      provider,
+      ephemeralAddress,
+      RelayAdapt7702ExecutionType.ExecuteWithNonce,
+    );
+
+    expect(nonce).to.equal(0n);
+  });
+
+  it('should return zero nonce when nonce call returns empty data', async () => {
+    const badDataError = new Error('could not decode result data (value="0x", info={ "method": "nonce", "signature": "nonce()" })') as Error & { code: string };
+    badDataError.code = 'BAD_DATA';
+    const provider = createProvider(
+      async () => '0x7702',
+      async () => {
+        throw badDataError;
+      },
+    );
+
+    const nonce = await getRelayAdapt7702ExecuteNonce(
+      provider,
+      ephemeralAddress,
+      RelayAdapt7702ExecutionType.ExecuteWithNonce,
+    );
+
+    expect(nonce).to.equal(0n);
+  });
+
+  it('should rethrow non-empty nonce read errors', async () => {
+    const providerError = new Error('provider unavailable');
+    const provider = createProvider(
+      async () => '0x7702',
+      async () => {
+        throw providerError;
+      },
+    );
+
+    let thrownError: Optional<Error>;
+    try {
+      await getRelayAdapt7702ExecuteNonce(
+        provider,
+        ephemeralAddress,
+        RelayAdapt7702ExecutionType.ExecuteWithNonce,
+      );
+    } catch (err) {
+      thrownError = err as Error;
+    }
+
+    expect(thrownError).to.equal(providerError);
+  });
 
   it('should encode current nonce-aware execute calldata', () => {
     const data = encodeRelayAdapt7702Execute([], actionData, signature, {

--- a/src/services/railgun/wallets/__tests__/wallets.test.ts
+++ b/src/services/railgun/wallets/__tests__/wallets.test.ts
@@ -5,6 +5,7 @@ import {
   createRailgunWallet,
   createViewOnlyRailgunWallet,
   fullWalletForID,
+  getCurrentEphemeralAddress,
   getRailgunAddress,
   getWalletMnemonic,
   getWalletShareableViewingKey,
@@ -13,6 +14,7 @@ import {
   validateRailgunAddress,
   viewOnlyWalletForID,
 } from '../wallets';
+import { HDNodeWallet } from 'ethers';
 import {
   MOCK_DB_ENCRYPTION_KEY,
   MOCK_MNEMONIC_2,
@@ -179,6 +181,29 @@ describe('wallets', () => {
         false, // isViewOnlyWallet
       ),
     ).rejectedWith('Could not load RAILGUN wallet');
+  });
+
+  it('Should resolve the current ephemeral address to a pinned override (7702 authority == to)', async () => {
+    // Level 2 single-sources `to`/recipients on the signer's address. With an override pinned,
+    // getCurrentEphemeralAddress must return the override address (the EIP-7702 authorization
+    // authority), not a separately-derived HD wallet — otherwise `to` != authority and the
+    // sponsored execute no-ops on-chain.
+    // Resolve the live wallet instance — an earlier spec unloads/reloads wallet.id, replacing
+    // the engine's instance, so mutate the one getCurrentEphemeralAddress will actually resolve.
+    const liveWallet = fullWalletForID(wallet.id);
+    const override = HDNodeWallet.createRandom();
+    await liveWallet.setCurrentEphemeralWallet(override);
+    try {
+      const address = await getCurrentEphemeralAddress(
+        wallet.id,
+        MOCK_DB_ENCRYPTION_KEY,
+        NetworkName.Ethereum,
+      );
+      expect(address).to.equal(override.address);
+    } finally {
+      // Shared fixture — clear the override so it cannot leak into other specs.
+      liveWallet.ephemeralWalletOverride = undefined;
+    }
   });
 
   it('Should validate RAILGUN addresses', async () => {

--- a/src/services/railgun/wallets/ephemeral-account.ts
+++ b/src/services/railgun/wallets/ephemeral-account.ts
@@ -1,0 +1,17 @@
+import { HDNodeWallet } from 'ethers';
+
+export class EphemeralAccount {
+  private wallet: HDNodeWallet;
+
+  constructor(wallet: HDNodeWallet) {
+    this.wallet = wallet;
+  }
+
+  get address(): string {
+    return this.wallet.address;
+  }
+
+  get signer(): HDNodeWallet {
+    return this.wallet;
+  }
+}

--- a/src/services/railgun/wallets/ephemeral-key-manager.ts
+++ b/src/services/railgun/wallets/ephemeral-key-manager.ts
@@ -1,0 +1,82 @@
+import { RailgunWallet } from '@railgun-community/engine';
+import { Chain } from '@railgun-community/shared-models';
+import { EphemeralAccount } from './ephemeral-account';
+
+
+export class EphemeralKeyManager {
+  private railgunWallet: RailgunWallet;
+  private encryptionKey: string;
+
+  constructor(railgunWallet: RailgunWallet, encryptionKey: string) {
+    this.railgunWallet = railgunWallet;
+    this.encryptionKey = encryptionKey;
+  }
+
+  async getAccount(chainId: bigint, index: number): Promise<EphemeralAccount> {
+    const wallet = await this.railgunWallet.getEphemeralWallet(
+      this.encryptionKey,
+      chainId,
+      index,
+    );
+    return new EphemeralAccount(wallet);
+  }
+
+  async getCurrentAccount(chainId: bigint): Promise<EphemeralAccount> {
+    const index = await this.railgunWallet.getEphemeralKeyIndex(chainId);
+    return this.getAccount(chainId, index);
+  }
+
+  async getNextAccount(chainId: bigint): Promise<EphemeralAccount> {
+    const currentIndex = await this.railgunWallet.getEphemeralKeyIndex(chainId);
+    const nextIndex = currentIndex + 1;
+    await this.railgunWallet.setEphemeralKeyIndex(chainId, nextIndex);
+    return this.getAccount(chainId, nextIndex);
+  }
+
+  async scanHistoryForEphemeralIndex(
+    chain: Chain,
+    scanLimit = 100,
+  ): Promise<number> {
+    const chainId = BigInt(chain.id);
+    const history = await this.railgunWallet.getTransactionHistory(chain, undefined);
+
+    const unshieldRecipients = new Set<string>();
+    for (const entry of history) {
+      for (const unshield of entry.unshieldTokenAmounts) {
+        unshieldRecipients.add(unshield.recipientAddress.toLowerCase());
+      }
+    }
+
+    if (unshieldRecipients.size === 0) {
+      return 0;
+    }
+
+    let maxUsedIndex = -1;
+    let currentIndex = 0;
+    let gapCount = 0;
+    const gapLimit = 20;
+
+    while (currentIndex < scanLimit && gapCount < gapLimit) {
+      // eslint-disable-next-line no-await-in-loop
+      const account = await this.getAccount(chainId, currentIndex);
+      const address = account.address.toLowerCase();
+
+      if (unshieldRecipients.has(address)) {
+        maxUsedIndex = currentIndex;
+        gapCount = 0;
+      } else {
+        gapCount += 1;
+      }
+      currentIndex += 1;
+    }
+
+    const nextIndex = maxUsedIndex + 1;
+    const storedIndex = await this.railgunWallet.getEphemeralKeyIndex(chainId);
+
+    if (nextIndex > storedIndex) {
+      await this.railgunWallet.setEphemeralKeyIndex(chainId, nextIndex);
+    }
+
+    return nextIndex;
+  }
+}

--- a/src/services/railgun/wallets/ephemeral-key-manager.ts
+++ b/src/services/railgun/wallets/ephemeral-key-manager.ts
@@ -6,10 +6,12 @@ import { EphemeralAccount } from './ephemeral-account';
 export class EphemeralKeyManager {
   private railgunWallet: RailgunWallet;
   private encryptionKey: string;
+  private mnemonicPassword?: string;
 
-  constructor(railgunWallet: RailgunWallet, encryptionKey: string) {
+  constructor(railgunWallet: RailgunWallet, encryptionKey: string, mnemonicPassword?: string) {
     this.railgunWallet = railgunWallet;
     this.encryptionKey = encryptionKey;
+    this.mnemonicPassword = mnemonicPassword;
   }
 
   async getAccount(chainId: bigint, index: number): Promise<EphemeralAccount> {
@@ -17,6 +19,7 @@ export class EphemeralKeyManager {
       this.encryptionKey,
       chainId,
       index,
+      this.mnemonicPassword,
     );
     return new EphemeralAccount(wallet);
   }
@@ -27,9 +30,9 @@ export class EphemeralKeyManager {
   }
 
   async getNextAccount(chainId: bigint): Promise<EphemeralAccount> {
-    const currentIndex = await this.railgunWallet.getEphemeralKeyIndex(chainId);
-    const nextIndex = currentIndex + 1;
-    await this.railgunWallet.setEphemeralKeyIndex(chainId, nextIndex);
+    // Use the engine's atomic, per-chain-serialized ratchet so concurrent callers can't
+    // reuse the same ephemeral key/nonce.
+    const nextIndex = await this.railgunWallet.incrementEphemeralKeyIndex(chainId);
     return this.getAccount(chainId, nextIndex);
   }
 
@@ -70,13 +73,8 @@ export class EphemeralKeyManager {
       currentIndex += 1;
     }
 
+    // Raise the stored index atomically so a concurrent ratchet cannot be clobbered.
     const nextIndex = maxUsedIndex + 1;
-    const storedIndex = await this.railgunWallet.getEphemeralKeyIndex(chainId);
-
-    if (nextIndex > storedIndex) {
-      await this.railgunWallet.setEphemeralKeyIndex(chainId, nextIndex);
-    }
-
-    return nextIndex;
+    return this.railgunWallet.setEphemeralKeyIndexIfGreater(chainId, nextIndex);
   }
 }

--- a/src/services/railgun/wallets/index.ts
+++ b/src/services/railgun/wallets/index.ts
@@ -1,4 +1,6 @@
 export * from './balance-update';
 export * from './balances';
 export * from './wallets';
+export * from './ephemeral-account';
+export * from './ephemeral-key-manager';
 export * from '../history/transaction-history';

--- a/src/services/railgun/wallets/relay-adapt-7702-execution.ts
+++ b/src/services/railgun/wallets/relay-adapt-7702-execution.ts
@@ -1,7 +1,7 @@
 import { Network, NetworkName, NETWORK_CONFIG } from '@railgun-community/shared-models';
 import {
   ABIRelayAdapt7702,
-  ABIRelayAdapt7702_Legacy_PreExecuteNonce,
+  ABIRelayAdapt7702_Legacy_PreExecuteNonce as abiRelayAdapt7702LegacyPreExecuteNonce,
   RelayAdapt7702,
   RelayAdapt7702ExecutionDetails,
   RelayAdapt7702ExecutionType,
@@ -90,7 +90,7 @@ export const encodeRelayAdapt7702Execute = (
   executionDetails: RelayAdapt7702ExecutionDetails,
 ): string => {
   const abi = executionDetails.executionType === RelayAdapt7702ExecutionType.LegacyPreExecuteNonce
-    ? ABIRelayAdapt7702_Legacy_PreExecuteNonce
+    ? abiRelayAdapt7702LegacyPreExecuteNonce
     : ABIRelayAdapt7702;
   const iface = new Interface(abi);
   return RelayAdapt7702Helper.encodeExecute(

--- a/src/services/railgun/wallets/relay-adapt-7702-execution.ts
+++ b/src/services/railgun/wallets/relay-adapt-7702-execution.ts
@@ -1,0 +1,74 @@
+import { Network, NetworkName, NETWORK_CONFIG } from '@railgun-community/shared-models';
+import {
+  ABIRelayAdapt7702,
+  ABIRelayAdapt7702_Legacy_PreExecuteNonce,
+  RelayAdapt7702,
+  RelayAdapt7702ExecutionDetails,
+  RelayAdapt7702ExecutionType,
+  RelayAdapt7702Helper,
+  TransactionStructV2,
+} from '@railgun-community/engine';
+import { Contract, Interface, Provider } from 'ethers';
+
+export const getRelayAdapt7702ExecutionTypeForNetwork = (
+  networkName: NetworkName,
+): RelayAdapt7702ExecutionType => {
+  const network: Network = NETWORK_CONFIG[networkName];
+  return network.relayAdapt7702SupportsExecuteNonce
+    ? RelayAdapt7702ExecutionType.ExecuteWithNonce
+    : RelayAdapt7702ExecutionType.LegacyPreExecuteNonce;
+};
+
+export const getRelayAdapt7702ExecuteNonce = async (
+  provider: Provider,
+  ephemeralAddress: string,
+  executionType: RelayAdapt7702ExecutionType,
+): Promise<Optional<bigint>> => {
+  if (executionType === RelayAdapt7702ExecutionType.LegacyPreExecuteNonce) {
+    return undefined;
+  }
+
+  const nonceContract = new Contract(
+    ephemeralAddress,
+    ABIRelayAdapt7702,
+    provider,
+  ) as unknown as RelayAdapt7702;
+  return nonceContract.nonce();
+};
+
+export const getRelayAdapt7702ExecutionDetails = async (
+  provider: Provider,
+  networkName: NetworkName,
+  ephemeralAddress: string,
+): Promise<RelayAdapt7702ExecutionDetails> => {
+  const executionType = getRelayAdapt7702ExecutionTypeForNetwork(networkName);
+  const executeNonce = await getRelayAdapt7702ExecuteNonce(
+    provider,
+    ephemeralAddress,
+    executionType,
+  );
+
+  return {
+    executionType,
+    executeNonce,
+  };
+};
+
+export const encodeRelayAdapt7702Execute = (
+  transactions: TransactionStructV2[],
+  actionData: RelayAdapt7702.ActionDataStruct,
+  signature: string,
+  executionDetails: RelayAdapt7702ExecutionDetails,
+): string => {
+  const abi = executionDetails.executionType === RelayAdapt7702ExecutionType.LegacyPreExecuteNonce
+    ? ABIRelayAdapt7702_Legacy_PreExecuteNonce
+    : ABIRelayAdapt7702;
+  const iface = new Interface(abi);
+  return RelayAdapt7702Helper.encodeExecute(
+    iface,
+    transactions,
+    actionData,
+    signature,
+    executionDetails,
+  );
+};

--- a/src/services/railgun/wallets/relay-adapt-7702-execution.ts
+++ b/src/services/railgun/wallets/relay-adapt-7702-execution.ts
@@ -19,6 +19,21 @@ export const getRelayAdapt7702ExecutionTypeForNetwork = (
     : RelayAdapt7702ExecutionType.LegacyPreExecuteNonce;
 };
 
+const isEmptyNonceReadError = (err: unknown): boolean => {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+
+  const maybeCode = (err as { code?: unknown }).code;
+  if (maybeCode === 'BAD_DATA') {
+    return true;
+  }
+
+  return err.message.includes('could not decode result data')
+    && err.message.includes('nonce()')
+    && err.message.includes('0x');
+};
+
 export const getRelayAdapt7702ExecuteNonce = async (
   provider: Provider,
   ephemeralAddress: string,
@@ -28,12 +43,26 @@ export const getRelayAdapt7702ExecuteNonce = async (
     return undefined;
   }
 
+  const code = await provider.getCode(ephemeralAddress);
+  if (code === '0x') {
+    return 0n;
+  }
+
   const nonceContract = new Contract(
     ephemeralAddress,
     ABIRelayAdapt7702,
     provider,
   ) as unknown as RelayAdapt7702;
-  return nonceContract.nonce();
+
+  try {
+    return await nonceContract.nonce();
+  } catch (err) {
+    if (isEmptyNonceReadError(err)) {
+      return 0n;
+    }
+
+    throw err;
+  }
 };
 
 export const getRelayAdapt7702ExecutionDetails = async (

--- a/src/services/railgun/wallets/wallets.ts
+++ b/src/services/railgun/wallets/wallets.ts
@@ -13,6 +13,7 @@ import {
   TransactionStructV2,
   TransactionStructV3,
   RelayAdapt7702,
+  RelayAdapt7702ExecutionDetails,
 } from '@railgun-community/engine';
 import {
   RailgunWalletInfo,
@@ -25,6 +26,7 @@ import { onBalancesUpdate, onWalletPOIProofProgress } from './balance-update';
 import { reportAndSanitizeError } from '../../../utils/error';
 import { getEngine } from '../core/engine';
 import { getFallbackProviderForNetwork } from '../core/providers';
+import { getRelayAdapt7702ExecutionDetails } from './relay-adapt-7702-execution';
 
 export const awaitWalletScan = (walletID: string, chain: Chain) => {
   const wallet = walletForID(walletID);
@@ -425,7 +427,11 @@ export const sign7702Request = async (
   chainId: bigint,
   transactions: (TransactionStructV2 | TransactionStructV3)[],
   actionData: RelayAdapt7702.ActionDataStruct,
-): Promise<{ authorization: Authorization; signature: string }> => {
+): Promise<{
+  authorization: Authorization;
+  signature: string;
+  executionDetails: RelayAdapt7702ExecutionDetails;
+}> => {
   const wallet = fullWalletForID(walletID);
   const provider = getFallbackProviderForNetwork(networkName);
   const ephemeralWallet = (await wallet.getCurrentEphemeralWallet(
@@ -433,15 +439,27 @@ export const sign7702Request = async (
     chainId,
   )).connect(provider);
   const nonce = await ephemeralWallet.getNonce('latest');
+  const executionDetails = await getRelayAdapt7702ExecutionDetails(
+    provider,
+    networkName,
+    ephemeralWallet.address,
+  );
 
-  return wallet.sign7702Request(
+  const { authorization, signature } = await wallet.sign7702Request(
     encryptionKey,
     contractAddress,
     chainId,
     transactions,
     actionData,
     nonce,
+    executionDetails,
   );
+
+  return {
+    authorization,
+    signature,
+    executionDetails,
+  };
 };
 
 export const ratchetEphemeralAddress = async (

--- a/src/services/railgun/wallets/wallets.ts
+++ b/src/services/railgun/wallets/wallets.ts
@@ -435,16 +435,22 @@ export const sign7702Request = async (
 }> => {
   const wallet = fullWalletForID(walletID);
   const provider = getFallbackProviderForNetwork(networkName);
-  const ephemeralWallet = (await wallet.getCurrentEphemeralWallet(
+  // Single-source every ephemeral facet on the signer that will actually produce the
+  // authorization below. getCurrentEphemeralAddress resolves the signer's address (honoring the
+  // same override/provider precedence as sign7702Request), so the authorization nonce and the
+  // execute nonce are read from the authorization authority itself. Reading them from
+  // getCurrentEphemeralWallet instead desyncs when a custom signer provider is set (authority
+  // != nonce-source), which silently invalidates the on-chain authorization.
+  const ephemeralAddress = await wallet.getCurrentEphemeralAddress(
     encryptionKey,
     chainId,
     mnemonicPassword,
-  )).connect(provider);
-  const nonce = await ephemeralWallet.getNonce('latest');
+  );
+  const nonce = await provider.getTransactionCount(ephemeralAddress, 'latest');
   const executionDetails = await getRelayAdapt7702ExecutionDetails(
     provider,
     networkName,
-    ephemeralWallet.address,
+    ephemeralAddress,
   );
 
   const { authorization, signature } = await wallet.sign7702Request(
@@ -480,13 +486,13 @@ export const getCurrentEphemeralAddress = async (
   networkName: NetworkName,
   mnemonicPassword?: string,
 ): Promise<string> => {
-  const wallet = await getCurrentEphemeralWallet(
-    walletID,
-    encryptionKey,
-    networkName,
-    mnemonicPassword,
-  );
-  return wallet.address;
+  // Resolve the address of the signer that produces the EIP-7702 authorization (engine
+  // getCurrentEphemeralAddress -> getCurrentEphemeralSigner), NOT getCurrentEphemeralWallet.
+  // The two diverge when a custom signer provider is set; `to`/recipients must equal the
+  // authorization authority, so both are single-sourced on the signer here.
+  const wallet = fullWalletForID(walletID);
+  const chainId = BigInt(NETWORK_CONFIG[networkName].chain.id);
+  return wallet.getCurrentEphemeralAddress(encryptionKey, chainId, mnemonicPassword);
 };
 
 export const getCurrentEphemeralWallet = async (

--- a/src/services/railgun/wallets/wallets.ts
+++ b/src/services/railgun/wallets/wallets.ts
@@ -427,6 +427,7 @@ export const sign7702Request = async (
   chainId: bigint,
   transactions: (TransactionStructV2 | TransactionStructV3)[],
   actionData: RelayAdapt7702.ActionDataStruct,
+  mnemonicPassword?: string,
 ): Promise<{
   authorization: Authorization;
   signature: string;
@@ -437,6 +438,7 @@ export const sign7702Request = async (
   const ephemeralWallet = (await wallet.getCurrentEphemeralWallet(
     encryptionKey,
     chainId,
+    mnemonicPassword,
   )).connect(provider);
   const nonce = await ephemeralWallet.getNonce('latest');
   const executionDetails = await getRelayAdapt7702ExecutionDetails(
@@ -453,6 +455,7 @@ export const sign7702Request = async (
     actionData,
     nonce,
     executionDetails,
+    mnemonicPassword,
   );
 
   return {
@@ -475,8 +478,14 @@ export const getCurrentEphemeralAddress = async (
   walletID: string,
   encryptionKey: string,
   networkName: NetworkName,
+  mnemonicPassword?: string,
 ): Promise<string> => {
-  const wallet = await getCurrentEphemeralWallet(walletID, encryptionKey, networkName);
+  const wallet = await getCurrentEphemeralWallet(
+    walletID,
+    encryptionKey,
+    networkName,
+    mnemonicPassword,
+  );
   return wallet.address;
 };
 
@@ -484,8 +493,9 @@ export const getCurrentEphemeralWallet = async (
   walletID: string,
   encryptionKey: string,
   networkName: NetworkName,
+  mnemonicPassword?: string,
 ) => {
   const wallet = fullWalletForID(walletID);
   const chainId = BigInt(NETWORK_CONFIG[networkName].chain.id);
-  return wallet.getCurrentEphemeralWallet(encryptionKey, chainId);
+  return wallet.getCurrentEphemeralWallet(encryptionKey, chainId, mnemonicPassword);
 };

--- a/src/services/railgun/wallets/wallets.ts
+++ b/src/services/railgun/wallets/wallets.ts
@@ -1,3 +1,4 @@
+import { Authorization, getAddress } from 'ethers';
 import {
   RailgunWallet,
   EngineEvent,
@@ -9,6 +10,9 @@ import {
   ByteUtils,
   POICurrentProofEventData,
   ViewOnlyWallet,
+  TransactionStructV2,
+  TransactionStructV3,
+  RelayAdapt7702,
 } from '@railgun-community/engine';
 import {
   RailgunWalletInfo,
@@ -19,8 +23,8 @@ import {
 } from '@railgun-community/shared-models';
 import { onBalancesUpdate, onWalletPOIProofProgress } from './balance-update';
 import { reportAndSanitizeError } from '../../../utils/error';
-import { getAddress } from 'ethers';
 import { getEngine } from '../core/engine';
+import { getFallbackProviderForNetwork } from '../core/providers';
 
 export const awaitWalletScan = (walletID: string, chain: Chain) => {
   const wallet = walletForID(walletID);
@@ -411,4 +415,59 @@ const formatCreationBlockNumbers = (
   }
 
   return formattedCreationBlockNumbers;
+};
+
+export const sign7702Request = async (
+  walletID: string,
+  encryptionKey: string,
+  networkName: NetworkName,
+  contractAddress: string,
+  chainId: bigint,
+  transactions: (TransactionStructV2 | TransactionStructV3)[],
+  actionData: RelayAdapt7702.ActionDataStruct,
+): Promise<{ authorization: Authorization; signature: string }> => {
+  const wallet = fullWalletForID(walletID);
+  const provider = getFallbackProviderForNetwork(networkName);
+  const ephemeralWallet = (await wallet.getCurrentEphemeralWallet(
+    encryptionKey,
+    chainId,
+  )).connect(provider);
+  const nonce = await ephemeralWallet.getNonce('latest');
+
+  return wallet.sign7702Request(
+    encryptionKey,
+    contractAddress,
+    chainId,
+    transactions,
+    actionData,
+    nonce,
+  );
+};
+
+export const ratchetEphemeralAddress = async (
+  walletID: string,
+  networkName: NetworkName,
+): Promise<void> => {
+  const wallet = fullWalletForID(walletID);
+  const chainId = BigInt(NETWORK_CONFIG[networkName].chain.id);
+  return wallet.ratchetEphemeralAddress(chainId);
+};
+
+export const getCurrentEphemeralAddress = async (
+  walletID: string,
+  encryptionKey: string,
+  networkName: NetworkName,
+): Promise<string> => {
+  const wallet = await getCurrentEphemeralWallet(walletID, encryptionKey, networkName);
+  return wallet.address;
+};
+
+export const getCurrentEphemeralWallet = async (
+  walletID: string,
+  encryptionKey: string,
+  networkName: NetworkName,
+) => {
+  const wallet = fullWalletForID(walletID);
+  const chainId = BigInt(NETWORK_CONFIG[networkName].chain.id);
+  return wallet.getCurrentEphemeralWallet(encryptionKey, chainId);
 };

--- a/src/services/transactions/__tests__/tx-cross-contract-calls-7702.test.ts
+++ b/src/services/transactions/__tests__/tx-cross-contract-calls-7702.test.ts
@@ -395,6 +395,8 @@ describe('tx-cross-contract-calls-7702', () => {
 
     expect(response.gasEstimate).to.be.a('bigint');
     expect(response.gasEstimate >= MINIMUM_RELAY_ADAPT_CROSS_CONTRACT_CALLS_GAS_LIMIT_V2).to.be.true;
+    const signActionData = signEIP7702AuthorizationStub.firstCall.args[6];
+    expect(signActionData.requireSuccess).to.equal(false);
   }).timeout(10_000);
 
   it('Should get gas estimates for valid cross contract calls, public wallet', async () => {
@@ -419,6 +421,8 @@ describe('tx-cross-contract-calls-7702', () => {
     expect(response.broadcasterFeeCommitment).to.be.undefined;
     expect(response.gasEstimate).to.be.a('bigint');
     expect(response.gasEstimate >= MINIMUM_RELAY_ADAPT_CROSS_CONTRACT_CALLS_GAS_LIMIT_V2).to.be.true;
+    const signActionData = signEIP7702AuthorizationStub.firstCall.args[6];
+    expect(signActionData.requireSuccess).to.equal(false);
     expect(addUnshieldDataSpy.called).to.be.true;
     expect(addUnshieldDataSpy.args).to.deep.equal([
       [
@@ -591,6 +595,8 @@ describe('tx-cross-contract-calls-7702', () => {
       ], // actual proof - nft 1
     ]);
 
+    const signActionData = signEIP7702AuthorizationStub.firstCall.args[6];
+    expect(signActionData.requireSuccess).to.equal(false);
 
     const populateResponse = await populateProvedCrossContractCalls(
       txidVersion,

--- a/src/services/transactions/__tests__/tx-cross-contract-calls-7702.test.ts
+++ b/src/services/transactions/__tests__/tx-cross-contract-calls-7702.test.ts
@@ -10,6 +10,7 @@ import {
   RelayAdapt7702Helper,
   RelayAdaptVersionedSmartContracts,
   RailgunVersionedSmartContracts,
+  RelayAdapt7702ExecutionType,
   TXIDVersion,
 } from '@railgun-community/engine';
 import {
@@ -266,6 +267,10 @@ describe('tx-cross-contract-calls-7702', () => {
       },
       signature:
         '0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+      executionDetails: {
+        executionType: RelayAdapt7702ExecutionType.ExecuteWithNonce,
+        executeNonce: 0n,
+      },
     });
 
     Sinon.stub(Wallets, 'getCurrentEphemeralAddress').resolves(

--- a/src/services/transactions/__tests__/tx-cross-contract-calls-7702.test.ts
+++ b/src/services/transactions/__tests__/tx-cross-contract-calls-7702.test.ts
@@ -1,0 +1,682 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import Sinon, { SinonStub, SinonSpy } from 'sinon';
+import {
+  RailgunWallet,
+  TransactionBatch,
+  getTokenDataERC20,
+  MINIMUM_RELAY_ADAPT_CROSS_CONTRACT_CALLS_GAS_LIMIT_V2,
+  TransactionStructV2,
+  RelayAdapt7702Helper,
+  RelayAdaptVersionedSmartContracts,
+  RailgunVersionedSmartContracts,
+  TXIDVersion,
+} from '@railgun-community/engine';
+import {
+  NetworkName,
+  NETWORK_CONFIG,
+  RailgunERC20AmountRecipient,
+  isDefined,
+  TransactionGasDetails,
+  EVMGasType,
+  RailgunERC20Amount,
+} from '@railgun-community/shared-models';
+import {
+  closeTestEngine,
+  initTestEngine,
+  initTestEngineNetworks,
+} from '../../../tests/setup.test';
+import {
+  MOCK_BOUND_PARAMS_V2,
+  MOCK_COMMITMENTS,
+  MOCK_DB_ENCRYPTION_KEY,
+  MOCK_ETH_WALLET_ADDRESS,
+  MOCK_FEE_TOKEN_DETAILS,
+  MOCK_MNEMONIC,
+  MOCK_NULLIFIERS,
+  MOCK_TOKEN_AMOUNTS,
+  MOCK_TRANSACTION_GAS_DETAILS_SERIALIZED_TYPE_2,
+  MOCK_ERC20_RECIPIENTS,
+  MOCK_FORMATTED_BROADCASTER_FEE_COMMITMENT_CIPHERTEXT_V2,
+  MOCK_NFT_AMOUNTS,
+  MOCK_NFT_AMOUNT_RECIPIENTS,
+  MOCK_TOKEN_ADDRESS,
+  MOCK_TOKEN_ADDRESS_2,
+} from '../../../tests/mocks.test';
+import {
+  createRailgunWallet,
+  fullWalletForID,
+} from '../../railgun/wallets/wallets';
+import * as Wallets from '../../railgun/wallets/wallets';
+import { setCachedProvedTransaction } from '../proof-cache';
+import {
+  gasEstimateForUnprovenCrossContractCalls7702,
+  generateCrossContractCallsProof7702,
+} from '../tx-cross-contract-calls-7702';
+import { ContractTransaction, FallbackProvider, Wallet, Signature } from 'ethers';
+import { getTestTXIDVersion, isV2Test } from '../../../tests/helper.test';
+import { createNFTTokenDataFromRailgunNFTAmount, populateProvedCrossContractCalls } from '../tx-cross-contract-calls';
+
+let gasEstimateStub: SinonStub;
+let railProveStub: SinonStub;
+let railDummyProveStub: SinonStub;
+let signEIP7702AuthorizationStub: SinonStub;
+let signExecutionAuthorizationStub: SinonStub;
+let relayAdaptGasEstimateStub: SinonStub;
+let addUnshieldDataSpy: SinonSpy;
+let feesStub: SinonStub;
+
+let railgunWallet: RailgunWallet;
+let broadcasterFeeERC20AmountRecipient: RailgunERC20AmountRecipient;
+
+const TEST_NETWORK_NAME = NetworkName.Hardhat;
+
+const MOCK_FALLBACK_PROVIDER_JSON_CONFIG_HARDHAT = {
+  chainId: 31337,
+  providers: [
+    {
+      provider: process.env.HARDHAT_RPC_URL ?? 'http://127.0.0.1:8545',
+      priority: 1,
+      weight: 2,
+      maxLogsPerBatch: 5,
+      stallTimeout: 2500,
+    },
+  ],
+};
+
+const mockEphemeralWallet = {
+  address: MOCK_ETH_WALLET_ADDRESS,
+  privateKey: '0xprivate',
+} as unknown as Wallet;
+
+chai.use(chaiAsPromised);
+const { expect } = chai;
+
+const txidVersion = getTestTXIDVersion();
+
+
+const mockERC20TokenData0 = getTokenDataERC20(
+  MOCK_TOKEN_AMOUNTS[0].tokenAddress,
+);
+const mockERC20TokenData1 = getTokenDataERC20(
+  MOCK_TOKEN_AMOUNTS[1].tokenAddress,
+);
+const mockNFTTokenData0 = createNFTTokenDataFromRailgunNFTAmount(
+  MOCK_NFT_AMOUNTS[0],
+);
+const mockNFTTokenData1 = createNFTTokenDataFromRailgunNFTAmount(
+  MOCK_NFT_AMOUNTS[1],
+);
+
+
+const mockCrossContractCalls: ContractTransaction[] = [
+  {
+    to: MOCK_ETH_WALLET_ADDRESS,
+    data: '0x0789',
+    value: 0n,
+  },
+];
+
+const MOCK_TOKEN_AMOUNTS_DIFFERENT: RailgunERC20Amount[] = [
+  {
+    tokenAddress: MOCK_TOKEN_ADDRESS,
+    amount: 100n,
+  },
+  {
+    tokenAddress: MOCK_TOKEN_ADDRESS_2,
+    amount: 300n,
+  },
+];
+
+const overallBatchMinGasPrice = BigInt('0x1000');
+
+const minGasLimit = MINIMUM_RELAY_ADAPT_CROSS_CONTRACT_CALLS_GAS_LIMIT_V2;
+
+const gasDetails: TransactionGasDetails = {
+  evmGasType: EVMGasType.Type4,
+  gasEstimate: 2000n,
+  maxFeePerGas: overallBatchMinGasPrice,
+  maxPriorityFeePerGas: 0n,
+};
+
+
+const MOCK_TRANSACTION_STRUCT_V2: TransactionStructV2 = {
+  txidVersion: TXIDVersion.V2_PoseidonMerkle,
+  proof: {
+    a: { x: 1n, y: 2n },
+    b: { x: [3n, 4n], y: [5n, 6n] },
+    c: { x: 7n, y: 8n },
+  },
+  merkleRoot: '0x0000000000000000000000000000000000000000000000000000000000000001',
+  nullifiers: MOCK_NULLIFIERS,
+  commitments: MOCK_COMMITMENTS,
+  boundParams: {
+    treeNumber: 0n,
+    minGasPrice: 0n,
+    unshield: 0n,
+    chainID: 31337n,
+    adaptContract: MOCK_ETH_WALLET_ADDRESS,
+    adaptParams:
+      '0x0000000000000000000000000000000000000000000000000000000000000000',
+    commitmentCiphertext: MOCK_BOUND_PARAMS_V2.commitmentCiphertext as any,
+  },
+  unshieldPreimage: {
+    npk: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    token: {
+      tokenType: 0n,
+      tokenAddress: MOCK_TOKEN_AMOUNTS[0].tokenAddress,
+      tokenSubID: 0n,
+    },
+    value: 100n,
+  },
+};
+
+const stubRelayAdaptGasEstimate = () => {
+  relayAdaptGasEstimateStub = Sinon.stub(
+    RelayAdaptVersionedSmartContracts,
+    'estimateGasWithErrorHandler',
+  ).resolves(BigInt('200'));
+};
+
+const stubGasEstimateSuccess = () => {
+  gasEstimateStub = Sinon.stub(
+    FallbackProvider.prototype,
+    'estimateGas',
+  ).resolves(BigInt('200'));
+};
+
+const stubRelayAdaptGasEstimateFailure = () => {
+  relayAdaptGasEstimateStub = Sinon.stub(
+    RelayAdaptVersionedSmartContracts,
+    'estimateGasWithErrorHandler',
+  ).rejects(new Error('RelayAdapt multicall failed at index UNKNOWN.'));
+};
+
+const spyOnSetUnshield = () => {
+  addUnshieldDataSpy = Sinon.spy(TransactionBatch.prototype, 'addUnshieldData');
+};
+
+describe('tx-cross-contract-calls-7702', () => {
+  before(async function () {
+    this.timeout(30_000);
+
+    // Hardcode fees to avoid flaky on-chain fee reads during provider bootstrap.
+    feesStub = Sinon.stub(RailgunVersionedSmartContracts, 'fees').resolves({
+      shield: 0n,
+      unshield: 0n,
+      nft: 0n,
+    } as any);
+
+    await initTestEngine();
+    await initTestEngineNetworks(
+      TEST_NETWORK_NAME,
+      MOCK_FALLBACK_PROVIDER_JSON_CONFIG_HARDHAT,
+    );
+    const walletInfo = await createRailgunWallet(
+      MOCK_DB_ENCRYPTION_KEY,
+      MOCK_MNEMONIC,
+      undefined, // creationBlockNumbers
+    );
+    if (!isDefined(walletInfo)) {
+      throw new Error('Could not create railgun wallet');
+    }
+    railgunWallet = fullWalletForID(walletInfo.id);
+
+    const broadcasterWalletInfo = await createRailgunWallet(
+      MOCK_DB_ENCRYPTION_KEY,
+      MOCK_MNEMONIC,
+      undefined, // creationBlockNumbers
+    );
+    if (!isDefined(broadcasterWalletInfo)) {
+      throw new Error('Expected broadcasterWalletInfo');
+    }
+    const broadcasterRailgunAddress = broadcasterWalletInfo.railgunAddress;
+
+    broadcasterFeeERC20AmountRecipient = {
+      ...MOCK_TOKEN_AMOUNTS[0],
+      recipientAddress: broadcasterRailgunAddress,
+    };
+
+    railProveStub = Sinon.stub(
+      TransactionBatch.prototype,
+      'generateTransactions',
+    ).resolves({
+      provedTransactions: [MOCK_TRANSACTION_STRUCT_V2],
+      preTransactionPOIsPerTxidLeafPerList: {},
+    });
+
+    railDummyProveStub = Sinon.stub(
+      TransactionBatch.prototype,
+      'generateDummyTransactions',
+    ).resolves([MOCK_TRANSACTION_STRUCT_V2]);
+
+    signEIP7702AuthorizationStub = Sinon.stub(
+      Wallets,
+      'sign7702Request',
+    ).resolves({
+      authorization: {
+        chainId: 31337n,
+        address: NETWORK_CONFIG[TEST_NETWORK_NAME].relayAdapt7702Contract,
+        nonce: 0n,
+        signature: Signature.from({
+          r: '0x01',
+          s: '0x02',
+          yParity: 0,
+        }),
+      },
+      signature:
+        '0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+    });
+
+    Sinon.stub(Wallets, 'getCurrentEphemeralAddress').resolves(
+      MOCK_ETH_WALLET_ADDRESS,
+    );
+  });
+
+  afterEach(() => {
+    gasEstimateStub?.restore();
+    relayAdaptGasEstimateStub?.restore();
+    addUnshieldDataSpy?.restore();
+  });
+
+  after(async function () {
+    this.timeout(30_000);
+
+    await closeTestEngine();
+    feesStub?.restore();
+    railProveStub?.restore();
+    railDummyProveStub?.restore();
+    signEIP7702AuthorizationStub?.restore();
+    const getCurrentEphemeralAddressStub = Wallets.getCurrentEphemeralAddress as Partial<SinonStub>;
+    if (typeof getCurrentEphemeralAddressStub.restore === 'function') {
+      getCurrentEphemeralAddressStub.restore();
+    }
+  });
+  
+  // GAS ESTIMATE
+
+  it('Should get gas estimates for valid cross contract calls', async () => {
+    stubRelayAdaptGasEstimate();
+    spyOnSetUnshield();
+    const response = await gasEstimateForUnprovenCrossContractCalls7702(
+      txidVersion,
+      TEST_NETWORK_NAME,
+      railgunWallet.id,
+      MOCK_DB_ENCRYPTION_KEY,
+      MOCK_TOKEN_AMOUNTS, // unshieldERC20Amounts
+      MOCK_NFT_AMOUNTS, // unshieldNFTAmounts
+      MOCK_ERC20_RECIPIENTS, // shieldERC20Recipients
+      MOCK_NFT_AMOUNT_RECIPIENTS, // shieldNFTRecipients
+      mockCrossContractCalls,
+      MOCK_TRANSACTION_GAS_DETAILS_SERIALIZED_TYPE_2,
+      MOCK_FEE_TOKEN_DETAILS,
+      false, // sendWithPublicWallet
+      minGasLimit, // minGasLimit
+    );
+    expect(response.broadcasterFeeCommitment).to.not.be.undefined;
+    expect(response.broadcasterFeeCommitment?.commitmentCiphertext).to.deep.equal(
+    isV2Test()
+        ? MOCK_FORMATTED_BROADCASTER_FEE_COMMITMENT_CIPHERTEXT_V2
+        : MOCK_FORMATTED_BROADCASTER_FEE_COMMITMENT_CIPHERTEXT_V2,
+    );
+    expect(addUnshieldDataSpy.called).to.be.true;
+
+    expect(addUnshieldDataSpy.args).to.deep.equal([
+      [
+        {
+          toAddress: mockEphemeralWallet.address,
+          tokenData: mockERC20TokenData0,
+          value: BigInt('0x0100'),
+          allowOverride: false,
+        },
+      ], // run 1 - erc20 1
+      [
+        {
+          toAddress: mockEphemeralWallet.address,
+          tokenData: mockERC20TokenData1,
+          value: BigInt('0x0200'),
+          allowOverride: false,
+        },
+      ], // run 1 - erc20 2
+      [
+        {
+          toAddress: mockEphemeralWallet.address,
+          tokenData: mockNFTTokenData0,
+          value: BigInt('1'),
+          allowOverride: false,
+        },
+      ], // run 1 - nft 0
+      [
+        {
+          toAddress: mockEphemeralWallet.address,
+          tokenData: mockNFTTokenData1,
+          value: BigInt('2'),
+          allowOverride: false,
+        },
+      ], // run 1 - nft 1
+      [
+        {
+          toAddress: mockEphemeralWallet.address,
+          tokenData: mockERC20TokenData0,
+          value: BigInt('0x0100'),
+          allowOverride: false,
+        },
+      ], // run 2 - erc20 1
+      [
+        {
+          toAddress: mockEphemeralWallet.address,
+          tokenData: mockERC20TokenData1,
+          value: BigInt('0x0200'),
+          allowOverride: false,
+        },
+      ], // run 2 - erc20 2
+      [
+        {
+          toAddress: mockEphemeralWallet.address,
+          tokenData: mockNFTTokenData0,
+          value: BigInt('1'),
+          allowOverride: false,
+        },
+      ], // run 2 - nft 0
+      [
+        {
+          toAddress: mockEphemeralWallet.address,
+          tokenData: mockNFTTokenData1,
+          value: BigInt('2'),
+          allowOverride: false,
+        },
+      ], // run 2 - nft 1
+    ]);
+
+    expect(response.gasEstimate).to.be.a('bigint');
+    expect(response.gasEstimate >= MINIMUM_RELAY_ADAPT_CROSS_CONTRACT_CALLS_GAS_LIMIT_V2).to.be.true;
+  }).timeout(10_000);
+
+  it('Should get gas estimates for valid cross contract calls, public wallet', async () => {
+    stubRelayAdaptGasEstimate();
+    spyOnSetUnshield();
+    const response = await gasEstimateForUnprovenCrossContractCalls7702(
+      txidVersion,
+      TEST_NETWORK_NAME,
+      railgunWallet.id,
+      MOCK_DB_ENCRYPTION_KEY,
+      MOCK_TOKEN_AMOUNTS, // unshieldERC20Amounts
+      MOCK_NFT_AMOUNTS, // unshieldNFTAmounts
+      MOCK_ERC20_RECIPIENTS, // shieldERC20Recipients
+      MOCK_NFT_AMOUNT_RECIPIENTS, // shieldNFTRecipients
+      mockCrossContractCalls,
+      MOCK_TRANSACTION_GAS_DETAILS_SERIALIZED_TYPE_2,
+      MOCK_FEE_TOKEN_DETAILS,
+      true, // sendWithPublicWallet
+      minGasLimit, // minGasLimit
+    );
+
+    expect(response.broadcasterFeeCommitment).to.be.undefined;
+    expect(response.gasEstimate).to.be.a('bigint');
+    expect(response.gasEstimate >= MINIMUM_RELAY_ADAPT_CROSS_CONTRACT_CALLS_GAS_LIMIT_V2).to.be.true;
+    expect(addUnshieldDataSpy.called).to.be.true;
+    expect(addUnshieldDataSpy.args).to.deep.equal([
+      [
+        {
+          toAddress: mockEphemeralWallet.address,
+          tokenData: mockERC20TokenData0,
+          value: BigInt('0x0100'),
+          allowOverride: false,
+        },
+      ], // run 1 - erc20 1
+      [
+        {
+          toAddress: mockEphemeralWallet.address,
+          tokenData: mockERC20TokenData1,
+          value: BigInt('0x0200'),
+          allowOverride: false,
+        },
+      ], // run 1 - erc20 2
+      [
+        {
+          toAddress: mockEphemeralWallet.address,
+          tokenData: mockNFTTokenData0,
+          value: BigInt('1'),
+          allowOverride: false,
+        },
+      ], // run 1 - nft 0
+      [
+        {
+          toAddress: mockEphemeralWallet.address,
+          tokenData: mockNFTTokenData1,
+          value: BigInt('2'),
+          allowOverride: false,
+        },
+      ], // run 1 - nft 1
+    ]);
+  }).timeout(10_000);
+
+  it('Should error on gas estimates for invalid cross contract calls', async () => {
+    stubGasEstimateSuccess();
+    await expect(
+      gasEstimateForUnprovenCrossContractCalls7702(
+        txidVersion,
+        TEST_NETWORK_NAME,
+        railgunWallet.id,
+        MOCK_DB_ENCRYPTION_KEY,
+        MOCK_TOKEN_AMOUNTS,
+        [],
+        MOCK_ERC20_RECIPIENTS,
+        [],
+        [{ data: 'abc' } as ContractTransaction], // Invalid
+        MOCK_TRANSACTION_GAS_DETAILS_SERIALIZED_TYPE_2,
+        MOCK_FEE_TOKEN_DETAILS,
+        false, // sendWithPublicWallet
+        undefined, // minGasLimit
+      ),
+    ).rejectedWith(
+      `Cross-contract calls require to and data fields (7702).`,
+    );
+  });
+
+  it('Should error on cross contract calls gas estimate for ethers rejections', async () => {
+    stubRelayAdaptGasEstimateFailure();
+    await expect(
+      gasEstimateForUnprovenCrossContractCalls7702(
+        txidVersion,
+        TEST_NETWORK_NAME,
+        railgunWallet.id,
+        MOCK_DB_ENCRYPTION_KEY,
+        MOCK_TOKEN_AMOUNTS, // unshieldERC20Amounts
+        MOCK_NFT_AMOUNTS, // unshieldNFTAmounts
+        MOCK_ERC20_RECIPIENTS, // shieldERC20Recipients
+        MOCK_NFT_AMOUNT_RECIPIENTS, // shieldNFTRecipients
+        mockCrossContractCalls,
+        MOCK_TRANSACTION_GAS_DETAILS_SERIALIZED_TYPE_2,
+        MOCK_FEE_TOKEN_DETAILS,
+        false, // sendWithPublicWallet
+        minGasLimit, // minGasLimit
+      ),
+    ).rejectedWith('RelayAdapt multicall failed at index UNKNOWN.');
+  });
+
+  // PROVE AND SEND
+
+  it('Should populate tx for valid cross contract calls', async () => {
+    stubGasEstimateSuccess();
+    setCachedProvedTransaction(undefined);
+    spyOnSetUnshield();
+    await generateCrossContractCallsProof7702(
+      txidVersion,
+      TEST_NETWORK_NAME,
+      railgunWallet.id,
+      MOCK_DB_ENCRYPTION_KEY,
+      MOCK_TOKEN_AMOUNTS, // unshieldERC20Amounts
+      MOCK_NFT_AMOUNTS, // unshieldNFTAmounts
+      MOCK_ERC20_RECIPIENTS, // shieldERC20Recipients
+      MOCK_NFT_AMOUNT_RECIPIENTS, // shieldNFTRecipients
+      mockCrossContractCalls,
+      broadcasterFeeERC20AmountRecipient,
+      false, // sendWithPublicWallet
+      overallBatchMinGasPrice, // overallBatchMinGasPrice
+      minGasLimit, // minGasLimit
+      () => {}, // progressCallback
+    );
+
+    expect(addUnshieldDataSpy.called).to.be.true;
+    expect(addUnshieldDataSpy.args).to.deep.equal([
+      [
+        {
+          toAddress: mockEphemeralWallet.address,
+          tokenData: mockERC20TokenData0,
+          value: BigInt('0x0100'),
+          allowOverride: false,
+        },
+      ], // dummy proof - erc20 token 0
+      [
+        {
+          toAddress: mockEphemeralWallet.address,
+          tokenData: mockERC20TokenData1,
+          value: BigInt('0x0200'),
+          allowOverride: false,
+        },
+      ], // dummy proof - erc20 token 1
+      [
+        {
+          toAddress: mockEphemeralWallet.address,
+          tokenData: mockNFTTokenData0,
+          value: BigInt('1'),
+          allowOverride: false,
+        },
+      ], // dummy proof - nft 0
+      [
+        {
+          toAddress: mockEphemeralWallet.address,
+          tokenData: mockNFTTokenData1,
+          value: BigInt('2'),
+          allowOverride: false,
+        },
+      ], // actual proof - nft 1
+      [
+        {
+          toAddress: mockEphemeralWallet.address,
+          tokenData: mockERC20TokenData0,
+          value: BigInt('0x0100'),
+          allowOverride: false,
+        },
+      ], // actual proof - erc20 token 0
+      [
+        {
+          toAddress: mockEphemeralWallet.address,
+          tokenData: mockERC20TokenData1,
+          value: BigInt('0x0200'),
+          allowOverride: false,
+        },
+      ], // actual proof - erc20 token 1
+      [
+        {
+          toAddress: mockEphemeralWallet.address,
+          tokenData: mockNFTTokenData0,
+          value: BigInt('1'),
+          allowOverride: false,
+        },
+      ], // actual proof - nft 0
+      [
+        {
+          toAddress: mockEphemeralWallet.address,
+          tokenData: mockNFTTokenData1,
+          value: BigInt('2'),
+          allowOverride: false,
+        },
+      ], // actual proof - nft 1
+    ]);
+
+
+    const populateResponse = await populateProvedCrossContractCalls(
+      txidVersion,
+      TEST_NETWORK_NAME,
+      railgunWallet.id,
+      MOCK_TOKEN_AMOUNTS,
+      MOCK_NFT_AMOUNTS,
+      MOCK_ERC20_RECIPIENTS,
+      MOCK_NFT_AMOUNT_RECIPIENTS,
+      mockCrossContractCalls,
+      broadcasterFeeERC20AmountRecipient,
+      false, // sendWithPublicWallet
+      overallBatchMinGasPrice,
+      gasDetails, // gasDetails
+    );
+    expect(populateResponse.nullifiers).to.deep.equal([
+      '0x0000000000000000000000000000000000000000000000000000000000000001',
+      '0x0000000000000000000000000000000000000000000000000000000000000002',
+    ]);
+
+    const { transaction } = populateResponse;
+
+    expect(transaction.nonce).to.equal(undefined);
+    expect(transaction.gasPrice).to.equal(undefined);
+    expect(transaction.maxFeePerGas?.toString()).to.equal('4096');
+    expect(transaction.maxPriorityFeePerGas?.toString()).to.equal('0');
+    expect(transaction.gasLimit).to.equal(2400n);
+    expect(transaction.value?.toString()).to.equal('0');
+    expect(transaction.data).to.not.equal(undefined);
+    expect(transaction.to).to.equal(mockEphemeralWallet.address);
+    expect(transaction.chainId).to.equal(undefined);
+    expect(transaction.type).to.equal(4);
+  });
+
+  it('Should error on populate cross contract calls tx when params changed (invalid cached proof)', async () => {
+    stubGasEstimateSuccess();
+    await generateCrossContractCallsProof7702(
+      txidVersion,
+      TEST_NETWORK_NAME,
+      railgunWallet.id,
+      MOCK_DB_ENCRYPTION_KEY,
+      MOCK_TOKEN_AMOUNTS,
+      MOCK_NFT_AMOUNTS,
+      MOCK_ERC20_RECIPIENTS,
+      MOCK_NFT_AMOUNT_RECIPIENTS,
+      mockCrossContractCalls,
+      broadcasterFeeERC20AmountRecipient,
+      false, // sendWithPublicWallet
+      overallBatchMinGasPrice,
+      minGasLimit,
+      () => {}, // progressCallback
+    );
+    await expect(
+      populateProvedCrossContractCalls(
+        txidVersion,
+        TEST_NETWORK_NAME,
+        railgunWallet.id,
+        MOCK_TOKEN_AMOUNTS_DIFFERENT,
+        MOCK_NFT_AMOUNTS,
+        MOCK_ERC20_RECIPIENTS,
+        MOCK_NFT_AMOUNT_RECIPIENTS,
+        mockCrossContractCalls,
+        broadcasterFeeERC20AmountRecipient,
+        false, // sendWithPublicWallet
+        overallBatchMinGasPrice,
+        gasDetails,
+      ),
+    ).rejectedWith('Invalid proof for this transaction');
+  });
+
+  it('Should error on generate proof for invalid cross contract calls', async () => {
+    stubGasEstimateSuccess();
+    await expect(
+      generateCrossContractCallsProof7702(
+        txidVersion,
+        TEST_NETWORK_NAME,
+        railgunWallet.id,
+        MOCK_DB_ENCRYPTION_KEY,
+        MOCK_TOKEN_AMOUNTS, // unshieldERC20Amounts
+        [], // unshieldNFTAmounts
+        MOCK_ERC20_RECIPIENTS, // shieldERC20Recipients
+        [], // shieldNFTRecipients
+        [{ data: 'abc' } as ContractTransaction], // Invalid
+        broadcasterFeeERC20AmountRecipient,
+        false, // sendWithPublicWallet
+        undefined, // overallBatchMinGasPrice
+        undefined, // minGasLimit
+        () => {}, // progressCallback
+      ),
+    ).rejectedWith(
+      `Cross-contract calls require to and data fields (7702).`,
+    );
+  });
+}).timeout(30_000);

--- a/src/services/transactions/__tests__/tx-gas-details.test.ts
+++ b/src/services/transactions/__tests__/tx-gas-details.test.ts
@@ -29,11 +29,10 @@ chai.use(chaiAsPromised);
 const { expect } = chai;
 
 
-const stubGasEstimateSuccess = () => {
-  gasEstimateStub = Sinon.stub(
-    FallbackProvider.prototype,
-    'estimateGas',
-  ).resolves(BigInt('200'));
+const stubGasEstimateSuccess = (fallbackProvider: any) => {
+  gasEstimateStub = Sinon.stub(fallbackProvider, 'estimateGas').resolves(
+    BigInt('200'),
+  );
 };
 
 describe('tx-gas', () => {
@@ -77,10 +76,10 @@ describe('tx-gas', () => {
   }).timeout(6000);
 
   it('Should pull gas estimate for basic transaction - self-signed', async () => {
-    stubGasEstimateSuccess();
     const fallbackProvider = createFallbackProviderFromJsonConfig(
       MOCK_FALLBACK_PROVIDER_JSON_CONFIG_POLYGON,
     );
+    stubGasEstimateSuccess(fallbackProvider as any);
     setFallbackProviderForNetwork(
       NetworkName.Polygon,
       fallbackProvider as unknown as FallbackProvider,
@@ -110,10 +109,10 @@ describe('tx-gas', () => {
   }).timeout(60_000);
 
   it('Should pull gas estimate for basic transaction - broadcaster', async () => {
-    stubGasEstimateSuccess();
     const fallbackProvider = createFallbackProviderFromJsonConfig(
       MOCK_FALLBACK_PROVIDER_JSON_CONFIG_POLYGON,
     );
+    stubGasEstimateSuccess(fallbackProvider as any);
     setFallbackProviderForNetwork(
       NetworkName.Polygon,
       fallbackProvider as unknown as FallbackProvider,

--- a/src/services/transactions/__tests__/tx-shield-base-token-7702.test.ts
+++ b/src/services/transactions/__tests__/tx-shield-base-token-7702.test.ts
@@ -1,0 +1,74 @@
+import { expect } from 'chai';
+import Sinon from 'sinon';
+import { HDNodeWallet, Provider } from 'ethers';
+import {
+  RelayAdapt7702Helper,
+  RelayAdapt7702ExecutionType,
+  ShieldRequestStruct,
+  TXIDVersion,
+} from '@railgun-community/engine';
+import { NetworkName } from '@railgun-community/shared-models';
+import { createShieldBaseTokenTransaction7702 } from '../tx-shield-base-token-7702';
+import { EphemeralAccount } from '../../railgun/wallets/ephemeral-account';
+import * as RelayAdapt7702Execution from '../../railgun/wallets/relay-adapt-7702-execution';
+
+const BYTES32 = `0x${'00'.repeat(32)}`;
+
+const MOCK_SHIELD_REQUEST: ShieldRequestStruct = {
+  preimage: {
+    npk: BYTES32,
+    token: { tokenType: 0, tokenAddress: `0x${'00'.repeat(20)}`, tokenSubID: 0n },
+    value: 1000n,
+  },
+  ciphertext: {
+    encryptedBundle: [BYTES32, BYTES32, BYTES32],
+    shieldKey: BYTES32,
+  },
+};
+
+describe('tx-shield-base-token-7702', () => {
+  afterEach(() => {
+    Sinon.restore();
+  });
+
+  // Regression guard for the shield-path authorization-nonce fix. The EIP-7702 authorization
+  // nonce must equal the ephemeral EOA's current account nonce; the shield path used to hardcode
+  // 0 (stale on a reused ephemeral account -> the authorization is skipped on-chain -> a silent
+  // no-op shield). It must now read the live account nonce, matching the cross-contract/unshield
+  // paths. Everything except that read is stubbed so the assertion is unambiguous.
+  it('reads the ephemeral EOA account nonce live for the 7702 authorization (not a hardcoded 0)', async () => {
+    const LIVE_NONCE = 5;
+    const getTransactionCount = Sinon.stub().resolves(LIVE_NONCE);
+    const fakeProvider = { getTransactionCount } as unknown as Provider;
+
+    const ephemeralAccount = new EphemeralAccount(
+      HDNodeWallet.createRandom().connect(fakeProvider),
+    );
+
+    // Isolate from the execute-nonce read and real EIP-712 signing.
+    Sinon.stub(RelayAdapt7702Execution, 'getRelayAdapt7702ExecutionDetails').resolves({
+      executionType: RelayAdapt7702ExecutionType.ExecuteWithNonce,
+      executeNonce: 3n,
+    });
+    const signAuthStub = Sinon.stub(RelayAdapt7702Helper, 'signEIP7702Authorization').resolves(
+      {} as never,
+    );
+    Sinon.stub(RelayAdapt7702Helper, 'signExecutionAuthorization').resolves(`0x${'11'.repeat(65)}`);
+
+    await createShieldBaseTokenTransaction7702(
+      TXIDVersion.V2_PoseidonMerkle,
+      NetworkName.Ethereum,
+      MOCK_SHIELD_REQUEST,
+      ephemeralAccount,
+    );
+
+    // The account nonce is read live for the ephemeral address...
+    expect(
+      getTransactionCount.calledOnceWithExactly(ephemeralAccount.address, 'latest'),
+    ).to.equal(true);
+    // ...and threaded into the authorization as its nonce (4th arg), not a literal 0.
+    expect(signAuthStub.calledOnce).to.equal(true);
+    expect(signAuthStub.firstCall.args[3]).to.equal(LIVE_NONCE);
+    expect(signAuthStub.firstCall.args[3]).to.not.equal(0);
+  });
+});

--- a/src/services/transactions/__tests__/tx-unshield.test.ts
+++ b/src/services/transactions/__tests__/tx-unshield.test.ts
@@ -64,9 +64,11 @@ import {
   createRailgunWallet,
   fullWalletForID,
 } from '../../railgun/wallets/wallets';
+import * as walletsModule from '../../railgun/wallets/wallets';
 import { setFallbackProviderForNetwork, fallbackProviderMap } from '../../railgun/core/providers';
 import { setCachedProvedTransaction } from '../proof-cache';
 import { ContractTransaction, FallbackProvider } from 'ethers';
+import * as txUnshieldBaseToken7702Module from '../tx-unshield-base-token-7702';
 import {
   MOCK_SHIELD_TXID_FOR_BALANCES,
   MOCK_TOKEN_BALANCE,
@@ -80,6 +82,8 @@ let railProveStub: SinonStub;
 let railDummyProveStub: SinonStub;
 let railTransactStub: SinonStub;
 let relayAdaptPopulateUnshieldBaseToken: SinonStub;
+let createUnshieldBaseTokenTransaction7702Stub: SinonStub;
+let getCurrentEphemeralAddressStub: SinonStub;
 let addUnshieldDataSpy: SinonSpy;
 let erc20NoteSpy: SinonSpy;
 
@@ -88,6 +92,8 @@ let broadcasterFeeERC20AmountRecipient: RailgunERC20AmountRecipient;
 
 const polygonRelayAdaptContract =
   NETWORK_CONFIG[NetworkName.Polygon].relayAdaptContract;
+
+let originalPolygonRelayAdapt7702Contract: Optional<string>;
 
 chai.use(chaiAsPromised);
 const { expect } = chai;
@@ -173,6 +179,14 @@ const spyOnSetUnshield = () => {
 describe('tx-unshield', () => {
   before(async function run() {
     this.timeout(60_000);
+
+    originalPolygonRelayAdapt7702Contract =
+      NETWORK_CONFIG[NetworkName.Polygon].relayAdapt7702Contract;
+    if (!NETWORK_CONFIG[NetworkName.Polygon].relayAdapt7702Contract) {
+      NETWORK_CONFIG[NetworkName.Polygon].relayAdapt7702Contract =
+        polygonRelayAdaptContract;
+    }
+
     await initTestEngine();
     await initTestEngineNetworks();
     const railgunWalletInfo = await createRailgunWallet(
@@ -230,6 +244,14 @@ describe('tx-unshield', () => {
       RelayAdaptVersionedSmartContracts,
       'populateUnshieldBaseToken',
     ).resolves({ data: '0x0123' } as ContractTransaction);
+    createUnshieldBaseTokenTransaction7702Stub = Sinon.stub(
+      txUnshieldBaseToken7702Module,
+      'createUnshieldBaseTokenTransaction7702',
+    ).resolves({ data: '0x0123' } as ContractTransaction);
+    getCurrentEphemeralAddressStub = Sinon.stub(
+      walletsModule,
+      'getCurrentEphemeralAddress',
+    ).resolves(polygonRelayAdaptContract);
 
     // For Unshield To Origin
     await createEngineWalletBalancesStub(
@@ -244,10 +266,15 @@ describe('tx-unshield', () => {
     erc20NoteSpy?.restore();
   });
   after(async () => {
+    NETWORK_CONFIG[NetworkName.Polygon].relayAdapt7702Contract =
+      originalPolygonRelayAdapt7702Contract ?? polygonRelayAdaptContract;
+
     railProveStub.restore();
     railDummyProveStub.restore();
     railTransactStub.restore();
     relayAdaptPopulateUnshieldBaseToken.restore();
+    createUnshieldBaseTokenTransaction7702Stub.restore();
+    getCurrentEphemeralAddressStub.restore();
     restoreEngineStubs();
     await closeTestEngine();
   });
@@ -475,18 +502,18 @@ describe('tx-unshield', () => {
 
   it('Should error on unshield base token gas estimate for ethers rejections', async () => {
     stubGasEstimateFailure();
-    await expect(
-      gasEstimateForUnprovenUnshieldBaseToken(
-        txidVersion,
-        NetworkName.Polygon,
-        MOCK_ETH_WALLET_ADDRESS,
-        railgunWallet.id,
-        MOCK_DB_ENCRYPTION_KEY,
-        MOCK_TOKEN_AMOUNTS[0],
-        MOCK_TRANSACTION_GAS_DETAILS_SERIALIZED_TYPE_2,
-        MOCK_FEE_TOKEN_DETAILS,
-        false, // sendWithPublicWallet
-      ),
+      await expect(
+        gasEstimateForUnprovenUnshieldBaseToken(
+          txidVersion,
+          NetworkName.Polygon,
+          MOCK_ETH_WALLET_ADDRESS,
+          railgunWallet.id,
+          MOCK_DB_ENCRYPTION_KEY,
+          MOCK_TOKEN_AMOUNTS[0],
+          MOCK_TRANSACTION_GAS_DETAILS_SERIALIZED_TYPE_2,
+          MOCK_FEE_TOKEN_DETAILS,
+          false, // sendWithPublicWallet
+        ),
     ).rejectedWith('test rejection - gas estimate');
   });
 

--- a/src/services/transactions/index.ts
+++ b/src/services/transactions/index.ts
@@ -1,6 +1,7 @@
 export * from './proof-cache';
 export * from './tx-cross-contract-calls';
 export * from './tx-shield-base-token';
+export * from './tx-shield-base-token-7702';
 export * from './tx-shield';
 export * from './tx-notes';
 export * from './tx-gas-details';
@@ -11,3 +12,5 @@ export * from './tx-proof-unshield';
 export * from './tx-nullifiers';
 export * from './tx-transfer';
 export * from './tx-unshield';
+export * from './tx-cross-contract-calls-7702';
+export * from './tx-unshield-base-token-7702';

--- a/src/services/transactions/tx-cross-contract-calls-7702.ts
+++ b/src/services/transactions/tx-cross-contract-calls-7702.ts
@@ -213,7 +213,7 @@ export const gasEstimateForUnprovenCrossContractCalls7702 = async (
           validCrossContractCalls,
           relayShieldRequests,
           ephemeralAddress,
-          true, // requireSuccess
+          false, // requireSuccess
           minimumGasLimit,
         );
 
@@ -369,7 +369,7 @@ export const generateCrossContractCallsProof7702 = async (
       validCrossContractCalls,
       relayShieldRequests,
       ephemeralAddress,
-      true, // requireSuccess
+      false, // requireSuccess
       minimumGasLimit,
     );
 

--- a/src/services/transactions/tx-cross-contract-calls-7702.ts
+++ b/src/services/transactions/tx-cross-contract-calls-7702.ts
@@ -151,6 +151,7 @@ export const gasEstimateForUnprovenCrossContractCalls7702 = async (
   feeTokenDetails: Optional<FeeTokenDetails>,
   sendWithPublicWallet: boolean,
   minGasLimit: Optional<bigint>,
+  mnemonicPassword?: string,
 ): Promise<RailgunTransactionGasEstimateResponse> => {
   try {
     setCachedProvedTransaction(undefined);
@@ -207,6 +208,8 @@ export const gasEstimateForUnprovenCrossContractCalls7702 = async (
           broadcasterFeeERC20Amount,
           sendWithPublicWallet,
           overallBatchMinGasPrice,
+          undefined, // originShieldTxidForSpendabilityOverride
+          mnemonicPassword,
         ),
       async (txs: (TransactionStructV2 | TransactionStructV3)[]) => {
         const actionData = await createActionData(
@@ -312,6 +315,7 @@ export const generateCrossContractCallsProof7702 = async (
   overallBatchMinGasPrice: Optional<bigint>,
   minGasLimit: Optional<bigint>,
   progressCallback: GenerateTransactionsProgressCallback,
+  mnemonicPassword?: string,
 ): Promise<RelayAdapt7702Request> => {
   try {
     setCachedProvedTransaction(undefined);
@@ -350,6 +354,8 @@ export const generateCrossContractCallsProof7702 = async (
       broadcasterFeeERC20AmountRecipient,
       sendWithPublicWallet,
       overallBatchMinGasPrice,
+      undefined, // originShieldTxidForSpendabilityOverride
+      mnemonicPassword,
     );
 
     // Generate relay adapt params from dummy transactions.
@@ -396,6 +402,8 @@ export const generateCrossContractCallsProof7702 = async (
         false, // useDummyProof
         overallBatchMinGasPrice,
         progressCallback,
+        undefined, // originShieldTxidForSpendabilityOverride
+        mnemonicPassword,
       );
 
     // Signatures

--- a/src/services/transactions/tx-cross-contract-calls-7702.ts
+++ b/src/services/transactions/tx-cross-contract-calls-7702.ts
@@ -1,0 +1,470 @@
+import {
+  RailgunTransactionGasEstimateResponse,
+  RailgunERC20Amount,
+  NetworkName,
+  ProofType,
+  FeeTokenDetails,
+  RailgunERC20AmountRecipient,
+  RailgunNFTAmountRecipient,
+  RailgunNFTAmount,
+  TransactionGasDetails,
+  RailgunERC20Recipient,
+  EVMGasType,
+  TXIDVersion,
+  NETWORK_CONFIG,
+} from '@railgun-community/shared-models';
+import {
+  GenerateTransactionsProgressCallback,
+  generateDummyProofTransactions,
+  generateProofTransactions,
+  nullifiersForTransactions,
+} from './tx-generator';
+import {
+  setCachedProvedTransaction,
+} from './proof-cache';
+import {
+  RelayAdaptHelper,
+  AdaptID,
+  ByteUtils,
+  MINIMUM_RELAY_ADAPT_CROSS_CONTRACT_CALLS_GAS_LIMIT_V2,
+  TransactionStructV2,
+  TransactionStructV3,
+  RelayAdapt7702Helper,
+  RelayAdapt7702,
+  RelayAdapt,
+  RelayAdapt__factory as RelayAdaptFactory,
+  RelayAdapt7702__factory as RelayAdapt7702Factory,
+  RelayAdapt7702Request,
+  ShieldRequestStruct,
+} from '@railgun-community/engine';
+import { assertNotBlockedAddress } from '../../utils/blocked-address';
+
+import { gasEstimateResponseDummyProofIterativeBroadcasterFee } from './tx-gas-broadcaster-fee-estimator';
+import { reportAndSanitizeError } from '../../utils/error';
+import { ContractTransaction } from 'ethers';
+import {
+  createRelayAdaptShieldNFTRecipients,
+} from './tx-cross-contract-calls';
+import { getCurrentEphemeralAddress, sign7702Request } from '../railgun/wallets/wallets';
+
+
+const RELAY_ADAPT_7702_EXECUTE_SIGNATURE =
+  'execute((((uint256,uint256),(uint256[2],uint256[2]),(uint256,uint256)),bytes32,bytes32[],bytes32[],(uint16,uint72,uint8,uint64,address,bytes32,(bytes32[4],bytes32,bytes32,bytes,bytes)[]),(bytes32,(uint8,address,uint256),uint120))[],(bool,uint256,(address,bytes,uint256)[]),bytes)';
+
+const encodeRelayAdapt7702Execute = (
+  transactions: TransactionStructV2[],
+  actionData: RelayAdapt7702.ActionDataStruct,
+  signature: string,
+): string => {
+  const iface = RelayAdapt7702Factory.createInterface();
+  return (iface as any).encodeFunctionData(RELAY_ADAPT_7702_EXECUTE_SIGNATURE, [
+    transactions,
+    actionData,
+    signature,
+  ]);
+};
+
+
+const createActionData = async (
+  validCrossContractCalls: ContractTransaction[],
+  relayShieldRequests: ShieldRequestStruct[],
+  ephemeralAddress: string,
+  requireSuccess: boolean,
+  minGasLimit: bigint,
+): Promise<RelayAdapt7702.ActionDataStruct> => {
+  const calls: ContractTransaction[] = [];
+
+  // Add Cross Contract Calls
+  for (const call of validCrossContractCalls) {
+    calls.push({
+      to: call.to,
+      data: call.data,
+      value: call.value ?? 0n,
+    });
+  }
+
+  // Add Shield Call
+  if (relayShieldRequests.length > 0) {
+    const relayAdaptInterface = RelayAdaptFactory.createInterface();
+    const shieldData = relayAdaptInterface.encodeFunctionData('shield', [relayShieldRequests]);
+    calls.push({
+      to: ephemeralAddress,
+      data: shieldData,
+      value: 0n,
+    });
+  }
+  return RelayAdapt7702Helper.getActionData(
+    requireSuccess,
+    calls,
+    minGasLimit,
+  );
+};
+
+// 7702 refactor for cross-contract calls
+
+// todo maybe import this from the og cross-contract call.
+const createValidCrossContractCalls = (
+  crossContractCalls: ContractTransaction[],
+): ContractTransaction[] => {
+  if (!crossContractCalls.length) {
+    throw new Error('No cross contract calls in transaction.');
+  }
+  try {
+    return crossContractCalls.map(transactionRequest => {
+      if (!transactionRequest.to || !transactionRequest.data) {
+        throw new Error(
+          `Cross-contract calls require to and data fields (7702).`,
+        );
+      }
+      const transaction: ContractTransaction = {
+        to: transactionRequest.to,
+        value: transactionRequest.value,
+        data: ByteUtils.hexlify(transactionRequest.data, true),
+      };
+      assertNotBlockedAddress(transaction.to);
+      return transaction;
+    });
+  } catch (cause) {
+    if (!(cause instanceof Error)) {
+      throw new Error('Non-error thrown from createValidCrossContractCalls', {
+        cause,
+      });
+    }
+    throw reportAndSanitizeError(createValidCrossContractCalls.name, cause);
+  }
+};
+
+export const createRelayAdapt7702UnshieldERC20AmountRecipients = (
+  unshieldERC20Amounts: RailgunERC20Amount[],
+  ephemeralAddress: string,
+): RailgunERC20AmountRecipient[] => {
+  return unshieldERC20Amounts.map(unshieldERC20Amount => ({
+    ...unshieldERC20Amount,
+    recipientAddress: ephemeralAddress,
+  }));
+};
+
+export const createRelayAdapt7702UnshieldNFTAmountRecipients = (
+  unshieldNFTAmounts: RailgunNFTAmount[],
+  ephemeralAddress: string,
+): RailgunNFTAmountRecipient[] => {
+  return unshieldNFTAmounts.map(unshieldNFTAmount => ({
+    ...unshieldNFTAmount,
+    recipientAddress: ephemeralAddress,
+  }));
+};
+
+export const gasEstimateForUnprovenCrossContractCalls7702 = async (
+  txidVersion: TXIDVersion,
+  networkName: NetworkName,
+  railgunWalletID: string,
+  encryptionKey: string,
+  relayAdaptUnshieldERC20Amounts: RailgunERC20Amount[],
+  relayAdaptUnshieldNFTAmounts: RailgunNFTAmount[],
+  relayAdaptShieldERC20Recipients: RailgunERC20Recipient[],
+  relayAdaptShieldNFTRecipients: RailgunNFTAmountRecipient[],
+  crossContractCalls: ContractTransaction[],
+  originalGasDetails: TransactionGasDetails,
+  feeTokenDetails: Optional<FeeTokenDetails>,
+  sendWithPublicWallet: boolean,
+  minGasLimit: Optional<bigint>,
+): Promise<RailgunTransactionGasEstimateResponse> => {
+  try {
+    setCachedProvedTransaction(undefined);
+
+    // Broadcaster fee estimation for 7702 must use Type4 fee semantics (maxFeePerGas).
+    // Coerce legacy inputs (eg. Type1 + gasPrice) to Type4 where possible.
+    const originalGasDetailsType4 = coerceGasDetailsToType4(originalGasDetails);
+
+    const overallBatchMinGasPrice = 0n;
+
+    const validCrossContractCalls =
+      createValidCrossContractCalls(crossContractCalls);
+
+    const ephemeralAddress = await getCurrentEphemeralAddress(
+      railgunWalletID,
+      encryptionKey,
+      networkName,
+    );
+
+    const relayAdaptUnshieldERC20AmountRecipients =
+      createRelayAdapt7702UnshieldERC20AmountRecipients(
+        relayAdaptUnshieldERC20Amounts,
+        ephemeralAddress,
+      );
+    const relayAdaptUnshieldNFTAmountRecipients =
+      createRelayAdapt7702UnshieldNFTAmountRecipients(
+        relayAdaptUnshieldNFTAmounts,
+        ephemeralAddress,
+      );
+
+    const shieldRandom = ByteUtils.randomHex(16);
+    const relayShieldRequests =
+      await RelayAdaptHelper.generateRelayShieldRequests(
+        shieldRandom,
+        relayAdaptShieldERC20Recipients,
+        createRelayAdaptShieldNFTRecipients(relayAdaptShieldNFTRecipients),
+      );
+
+    const minimumGasLimit =
+      minGasLimit ?? MINIMUM_RELAY_ADAPT_CROSS_CONTRACT_CALLS_GAS_LIMIT_V2;
+
+    const response = await gasEstimateResponseDummyProofIterativeBroadcasterFee(
+      (broadcasterFeeERC20Amount: Optional<RailgunERC20Amount>) =>
+        generateDummyProofTransactions(
+          ProofType.CrossContractCalls,
+          networkName,
+          railgunWalletID,
+          txidVersion,
+          encryptionKey,
+          false, // showSenderAddressToRecipient
+          undefined, // memoText
+          relayAdaptUnshieldERC20AmountRecipients,
+          relayAdaptUnshieldNFTAmountRecipients,
+          broadcasterFeeERC20Amount,
+          sendWithPublicWallet,
+          overallBatchMinGasPrice,
+        ),
+      async (txs: (TransactionStructV2 | TransactionStructV3)[]) => {
+        const actionData = await createActionData(
+          validCrossContractCalls,
+          relayShieldRequests,
+          ephemeralAddress,
+          true, // requireSuccess
+          minimumGasLimit,
+        );
+
+        const chainId = NETWORK_CONFIG[networkName].chain.id;
+        const { relayAdapt7702Contract } = NETWORK_CONFIG[networkName]
+        const transactions = txs as TransactionStructV2[];
+        const { authorization, signature } = await sign7702Request(
+          railgunWalletID,
+          encryptionKey,
+          networkName,
+          relayAdapt7702Contract,
+          BigInt(chainId),
+          transactions,
+          actionData,
+        );
+
+        const data = encodeRelayAdapt7702Execute(transactions, actionData, signature);
+
+        const transaction: ContractTransaction = {
+          to: ephemeralAddress, // Send to the ephemeral address (which will have code)
+          data,
+          value: 0n,
+          type: 4, // EIP-7702 Transaction Type
+          authorizationList: [authorization],
+        };
+        
+        return transaction;
+      },
+      txidVersion,
+      networkName,
+      railgunWalletID,
+      relayAdaptUnshieldERC20AmountRecipients,
+      originalGasDetailsType4,
+      feeTokenDetails,
+      sendWithPublicWallet,
+      true, // isCrossContractCall
+    );
+
+    if (response.gasEstimate) {
+      if (response.gasEstimate < minimumGasLimit) {
+        response.gasEstimate = minimumGasLimit;
+      }
+    }
+
+    return response;
+  } catch (err) {
+    throw reportAndSanitizeError(
+      gasEstimateForUnprovenCrossContractCalls7702.name,
+      err,
+    );
+  }
+};
+
+function coerceGasDetailsToType4(
+  gasDetails: TransactionGasDetails,
+): TransactionGasDetails {
+  if (gasDetails.evmGasType === EVMGasType.Type4) {
+    return gasDetails;
+  }
+  if (gasDetails.evmGasType === EVMGasType.Type2) {
+    return {
+      ...gasDetails,
+      evmGasType: EVMGasType.Type4,
+    };
+  }
+  if ('gasPrice' in gasDetails && gasDetails.gasPrice != null) {
+    return {
+      evmGasType: EVMGasType.Type4,
+      gasEstimate: gasDetails.gasEstimate,
+      maxFeePerGas: gasDetails.gasPrice,
+      maxPriorityFeePerGas: 0n,
+    };
+  }
+  throw new Error(
+    '7702 cross-contract call requires Type4 gas details (maxFeePerGas/maxPriorityFeePerGas).',
+  );
+}
+
+export const generateCrossContractCallsProof7702 = async (
+  txidVersion: TXIDVersion,
+  networkName: NetworkName,
+  railgunWalletID: string,
+  encryptionKey: string,
+  relayAdaptUnshieldERC20Amounts: RailgunERC20Amount[],
+  relayAdaptUnshieldNFTAmounts: RailgunNFTAmount[],
+  relayAdaptShieldERC20Recipients: RailgunERC20Recipient[],
+  relayAdaptShieldNFTRecipients: RailgunNFTAmountRecipient[],
+  crossContractCalls: ContractTransaction[],
+  broadcasterFeeERC20AmountRecipient: Optional<RailgunERC20AmountRecipient>,
+  sendWithPublicWallet: boolean,
+  overallBatchMinGasPrice: Optional<bigint>,
+  minGasLimit: Optional<bigint>,
+  progressCallback: GenerateTransactionsProgressCallback,
+): Promise<RelayAdapt7702Request> => {
+  try {
+    setCachedProvedTransaction(undefined);
+
+    const validCrossContractCalls =
+      createValidCrossContractCalls(crossContractCalls);
+
+    const ephemeralAddress = await getCurrentEphemeralAddress(
+      railgunWalletID,
+      encryptionKey,
+      networkName,
+    );
+
+    const relayAdaptUnshieldERC20AmountRecipients =
+      createRelayAdapt7702UnshieldERC20AmountRecipients(
+        relayAdaptUnshieldERC20Amounts,
+        ephemeralAddress,
+      );
+    const relayAdaptUnshieldNFTAmountRecipients =
+      createRelayAdapt7702UnshieldNFTAmountRecipients(
+        relayAdaptUnshieldNFTAmounts,
+        ephemeralAddress,
+      );
+
+    // Generate dummy txs for relay adapt params.
+    const dummyUnshieldTxs = await generateDummyProofTransactions(
+      ProofType.CrossContractCalls,
+      networkName,
+      railgunWalletID,
+      txidVersion,
+      encryptionKey,
+      false, // showSenderAddressToRecipient
+      undefined, // memoText
+      relayAdaptUnshieldERC20AmountRecipients,
+      relayAdaptUnshieldNFTAmountRecipients,
+      broadcasterFeeERC20AmountRecipient,
+      sendWithPublicWallet,
+      overallBatchMinGasPrice,
+    );
+
+    // Generate relay adapt params from dummy transactions.
+    const shieldRandom = ByteUtils.randomHex(16);
+
+    const relayShieldRequests =
+      await RelayAdaptHelper.generateRelayShieldRequests(
+        shieldRandom,
+        relayAdaptShieldERC20Recipients,
+        createRelayAdaptShieldNFTRecipients(relayAdaptShieldNFTRecipients),
+      );
+
+    const minimumGasLimit =
+      minGasLimit ?? MINIMUM_RELAY_ADAPT_CROSS_CONTRACT_CALLS_GAS_LIMIT_V2;
+
+    const actionData = await createActionData(
+      validCrossContractCalls,
+      relayShieldRequests,
+      ephemeralAddress,
+      true, // requireSuccess
+      minimumGasLimit,
+    );
+
+    const relayAdaptID: AdaptID = {
+      contract: ephemeralAddress,
+      parameters: RelayAdapt7702Helper.getZeroAdaptParams(),
+    };
+
+    // Create real transactions with relay adapt params.
+    const { provedTransactions, preTransactionPOIsPerTxidLeafPerList } =
+      await generateProofTransactions(
+        ProofType.CrossContractCalls,
+        networkName,
+        railgunWalletID,
+        txidVersion,
+        encryptionKey,
+        false, // showSenderAddressToRecipient
+        undefined, // memoText
+        relayAdaptUnshieldERC20AmountRecipients,
+        relayAdaptUnshieldNFTAmountRecipients,
+        broadcasterFeeERC20AmountRecipient,
+        sendWithPublicWallet,
+        relayAdaptID,
+        false, // useDummyProof
+        overallBatchMinGasPrice,
+        progressCallback,
+      );
+
+    // Signatures
+    const chainId = NETWORK_CONFIG[networkName].chain.id;
+    const { relayAdapt7702Contract } = NETWORK_CONFIG[networkName]
+    const transactions = provedTransactions as TransactionStructV2[];
+    const { authorization, signature: executionSignature } = await sign7702Request(
+      railgunWalletID,
+      encryptionKey,
+      networkName,
+      relayAdapt7702Contract,
+      BigInt(chainId),
+      transactions,
+      actionData,
+    );
+
+    // Construct the transaction data
+    const data = encodeRelayAdapt7702Execute(transactions, actionData, executionSignature);
+
+    const transaction: ContractTransaction = {
+      to: ephemeralAddress,
+      data,
+      value: 0n,
+      type: 4,
+      authorizationList: [authorization],
+    };
+
+    setCachedProvedTransaction({
+      proofType: ProofType.CrossContractCalls,
+      txidVersion,
+      railgunWalletID,
+      showSenderAddressToRecipient: false,
+      memoText: undefined,
+      erc20AmountRecipients: [],
+      nftAmountRecipients: [],
+      relayAdaptUnshieldERC20Amounts,
+      relayAdaptUnshieldNFTAmounts,
+      relayAdaptShieldERC20Recipients,
+      relayAdaptShieldNFTRecipients,
+      crossContractCalls: validCrossContractCalls,
+      broadcasterFeeERC20AmountRecipient,
+      sendWithPublicWallet,
+      transaction,
+      preTransactionPOIsPerTxidLeafPerList,
+      overallBatchMinGasPrice,
+      nullifiers: nullifiersForTransactions(provedTransactions),
+    });
+
+    return {
+      transactions,
+      actionData,
+      authorization,
+      executionSignature,
+      ephemeralAddress,
+    };
+
+  } catch (err) {
+    throw reportAndSanitizeError(generateCrossContractCallsProof7702.name, err);
+  }
+};

--- a/src/services/transactions/tx-cross-contract-calls-7702.ts
+++ b/src/services/transactions/tx-cross-contract-calls-7702.ts
@@ -33,7 +33,6 @@ import {
   RelayAdapt7702,
   RelayAdapt,
   RelayAdapt__factory as RelayAdaptFactory,
-  RelayAdapt7702__factory as RelayAdapt7702Factory,
   RelayAdapt7702Request,
   ShieldRequestStruct,
 } from '@railgun-community/engine';
@@ -46,23 +45,7 @@ import {
   createRelayAdaptShieldNFTRecipients,
 } from './tx-cross-contract-calls';
 import { getCurrentEphemeralAddress, sign7702Request } from '../railgun/wallets/wallets';
-
-
-const RELAY_ADAPT_7702_EXECUTE_SIGNATURE =
-  'execute((((uint256,uint256),(uint256[2],uint256[2]),(uint256,uint256)),bytes32,bytes32[],bytes32[],(uint16,uint72,uint8,uint64,address,bytes32,(bytes32[4],bytes32,bytes32,bytes,bytes)[]),(bytes32,(uint8,address,uint256),uint120))[],(bool,uint256,(address,bytes,uint256)[]),bytes)';
-
-const encodeRelayAdapt7702Execute = (
-  transactions: TransactionStructV2[],
-  actionData: RelayAdapt7702.ActionDataStruct,
-  signature: string,
-): string => {
-  const iface = RelayAdapt7702Factory.createInterface();
-  return (iface as any).encodeFunctionData(RELAY_ADAPT_7702_EXECUTE_SIGNATURE, [
-    transactions,
-    actionData,
-    signature,
-  ]);
-};
+import { encodeRelayAdapt7702Execute } from '../railgun/wallets/relay-adapt-7702-execution';
 
 
 const createActionData = async (
@@ -237,7 +220,7 @@ export const gasEstimateForUnprovenCrossContractCalls7702 = async (
         const chainId = NETWORK_CONFIG[networkName].chain.id;
         const { relayAdapt7702Contract } = NETWORK_CONFIG[networkName]
         const transactions = txs as TransactionStructV2[];
-        const { authorization, signature } = await sign7702Request(
+        const { authorization, signature, executionDetails } = await sign7702Request(
           railgunWalletID,
           encryptionKey,
           networkName,
@@ -247,7 +230,12 @@ export const gasEstimateForUnprovenCrossContractCalls7702 = async (
           actionData,
         );
 
-        const data = encodeRelayAdapt7702Execute(transactions, actionData, signature);
+        const data = encodeRelayAdapt7702Execute(
+          transactions,
+          actionData,
+          signature,
+          executionDetails,
+        );
 
         const transaction: ContractTransaction = {
           to: ephemeralAddress, // Send to the ephemeral address (which will have code)
@@ -414,7 +402,11 @@ export const generateCrossContractCallsProof7702 = async (
     const chainId = NETWORK_CONFIG[networkName].chain.id;
     const { relayAdapt7702Contract } = NETWORK_CONFIG[networkName]
     const transactions = provedTransactions as TransactionStructV2[];
-    const { authorization, signature: executionSignature } = await sign7702Request(
+    const {
+      authorization,
+      signature: executionSignature,
+      executionDetails,
+    } = await sign7702Request(
       railgunWalletID,
       encryptionKey,
       networkName,
@@ -425,7 +417,12 @@ export const generateCrossContractCallsProof7702 = async (
     );
 
     // Construct the transaction data
-    const data = encodeRelayAdapt7702Execute(transactions, actionData, executionSignature);
+    const data = encodeRelayAdapt7702Execute(
+      transactions,
+      actionData,
+      executionSignature,
+      executionDetails,
+    );
 
     const transaction: ContractTransaction = {
       to: ephemeralAddress,
@@ -462,6 +459,8 @@ export const generateCrossContractCallsProof7702 = async (
       authorization,
       executionSignature,
       ephemeralAddress,
+      executionType: executionDetails.executionType,
+      executeNonce: executionDetails.executeNonce,
     };
 
   } catch (err) {

--- a/src/services/transactions/tx-cross-contract-calls-7702.ts
+++ b/src/services/transactions/tx-cross-contract-calls-7702.ts
@@ -169,6 +169,7 @@ export const gasEstimateForUnprovenCrossContractCalls7702 = async (
       railgunWalletID,
       encryptionKey,
       networkName,
+      mnemonicPassword,
     );
 
     const relayAdaptUnshieldERC20AmountRecipients =
@@ -231,6 +232,7 @@ export const gasEstimateForUnprovenCrossContractCalls7702 = async (
           BigInt(chainId),
           transactions,
           actionData,
+          mnemonicPassword,
         );
 
         const data = encodeRelayAdapt7702Execute(
@@ -327,6 +329,7 @@ export const generateCrossContractCallsProof7702 = async (
       railgunWalletID,
       encryptionKey,
       networkName,
+      mnemonicPassword,
     );
 
     const relayAdaptUnshieldERC20AmountRecipients =
@@ -422,6 +425,7 @@ export const generateCrossContractCallsProof7702 = async (
       BigInt(chainId),
       transactions,
       actionData,
+      mnemonicPassword,
     );
 
     // Construct the transaction data

--- a/src/services/transactions/tx-cross-contract-calls.ts
+++ b/src/services/transactions/tx-cross-contract-calls.ts
@@ -128,7 +128,7 @@ export const createNFTTokenDataFromRailgunNFTAmount = (
   };
 };
 
-const createRelayAdaptShieldNFTRecipients = (
+export const createRelayAdaptShieldNFTRecipients = (
   relayAdaptShieldNFTRecipients: RailgunNFTAmountRecipient[],
 ): RelayAdaptShieldNFTRecipient[] => {
   return relayAdaptShieldNFTRecipients.map(

--- a/src/services/transactions/tx-gas-details.ts
+++ b/src/services/transactions/tx-gas-details.ts
@@ -34,7 +34,7 @@ export const getGasEstimate = async (
   const estimateGasTransactionRequest: ContractTransaction = {
     ...transaction,
     from: fromWalletAddress,
-    type: evmGasType,
+    type: transaction.type === 4 ? 4 : evmGasType,
   };
   if (shouldRemoveGasLimitForL2GasEstimate(networkName)) {
     delete estimateGasTransactionRequest.gasLimit;
@@ -127,7 +127,18 @@ export const setGasDetailsForTransaction = (
     sendWithPublicWallet,
   );
 
-  if (gasDetails.evmGasType !== evmGasType) {
+  const isEIP7702Type4Transaction = transaction.type === 4;
+
+  // EIP-7702 transactions (type 4) must remain type 4 and use EIP-1559-style fee fields.
+  // Some callers may still provide legacy gas details; coerce safely where possible.
+  const resolvedGasDetails: TransactionGasDetails = isEIP7702Type4Transaction
+    ? coerceGasDetailsToType4(gasDetails)
+    : gasDetails;
+
+  if (
+    resolvedGasDetails.evmGasType !== evmGasType &&
+    resolvedGasDetails.evmGasType !== EVMGasType.Type4
+  ) {
     const transactionType = sendWithPublicWallet
       ? 'self-signed'
       : 'Broadcaster';
@@ -137,28 +148,62 @@ export const setGasDetailsForTransaction = (
   }
 
   // eslint-disable-next-line no-param-reassign
-  transaction.type = gasDetails.evmGasType;
+  transaction.type = isEIP7702Type4Transaction
+    ? EVMGasType.Type4
+    : resolvedGasDetails.evmGasType;
 
-  switch (gasDetails.evmGasType) {
+  switch (resolvedGasDetails.evmGasType) {
     case EVMGasType.Type0: {
       // eslint-disable-next-line no-param-reassign
-      transaction.gasPrice = gasDetails.gasPrice;
+      transaction.gasPrice = resolvedGasDetails.gasPrice;
       // eslint-disable-next-line no-param-reassign
       delete transaction.accessList;
       break;
     }
     case EVMGasType.Type1: {
       // eslint-disable-next-line no-param-reassign
-      transaction.gasPrice = gasDetails.gasPrice;
+      transaction.gasPrice = resolvedGasDetails.gasPrice;
       break;
     }
     case EVMGasType.Type2: 
     case EVMGasType.Type4: {
       // eslint-disable-next-line no-param-reassign
-      transaction.maxFeePerGas = gasDetails.maxFeePerGas;
+      transaction.maxFeePerGas = resolvedGasDetails.maxFeePerGas;
       // eslint-disable-next-line no-param-reassign
-      transaction.maxPriorityFeePerGas = gasDetails.maxPriorityFeePerGas;
+      transaction.maxPriorityFeePerGas = resolvedGasDetails.maxPriorityFeePerGas;
+      // eslint-disable-next-line no-param-reassign
+      delete transaction.gasPrice;
       break;
     }
   }
 };
+
+function coerceGasDetailsToType4(
+  gasDetails: TransactionGasDetails,
+): TransactionGasDetails {
+  if (gasDetails.evmGasType === EVMGasType.Type4) {
+    return gasDetails;
+  }
+  if (gasDetails.evmGasType === EVMGasType.Type2) {
+    // Type2 and Type4 share EIP-1559 fee fields.
+    return {
+      ...gasDetails,
+      evmGasType: EVMGasType.Type4,
+    };
+  }
+
+  // Coerce legacy fee field into EIP-1559 maxFeePerGas.
+  // If the caller wants a separate maxPriorityFeePerGas, they must provide it.
+  if ('gasPrice' in gasDetails && gasDetails.gasPrice != null) {
+    return {
+      evmGasType: EVMGasType.Type4,
+      gasEstimate: gasDetails.gasEstimate,
+      maxFeePerGas: gasDetails.gasPrice,
+      maxPriorityFeePerGas: 0n,
+    };
+  }
+
+  throw new Error(
+    'EIP-7702 transaction requires Type4 gas details (maxFeePerGas/maxPriorityFeePerGas).',
+  );
+}

--- a/src/services/transactions/tx-proof-unshield.ts
+++ b/src/services/transactions/tx-proof-unshield.ts
@@ -202,6 +202,7 @@ export const generateUnshieldBaseTokenProof = async (
       railgunWalletID,
       encryptionKey,
       networkName,
+      mnemonicPassword,
     );
 
     const relayAdaptUnshieldERC20AmountRecipients: RailgunERC20AmountRecipient[] =
@@ -279,6 +280,7 @@ export const generateUnshieldBaseTokenProof = async (
       provedTransactions,
       actionData,
       ephemeralAddress,
+      mnemonicPassword,
     );
 
     const nullifiers = nullifiersForTransactions(provedTransactions);

--- a/src/services/transactions/tx-proof-unshield.ts
+++ b/src/services/transactions/tx-proof-unshield.ts
@@ -5,26 +5,32 @@ import {
   RailgunERC20AmountRecipient,
   RailgunNFTAmountRecipient,
   TXIDVersion,
-  NETWORK_CONFIG,
 } from '@railgun-community/shared-models';
 import {
   GenerateTransactionsProgressCallback,
   generateDummyProofTransactions,
   generateProofTransactions,
   generateTransact,
-  generateUnshieldBaseToken,
   nullifiersForTransactions,
 } from './tx-generator';
-import { assertValidEthAddress } from '../railgun/wallets/wallets';
+import {
+  assertValidEthAddress,
+  getCurrentEphemeralAddress,
+} from '../railgun/wallets/wallets';
 import { setCachedProvedTransaction } from './proof-cache';
 import {
   AdaptID,
-  RelayAdaptVersionedSmartContracts,
   ByteUtils,
+  RelayAdapt7702Helper,
+  TransactionStructV2,
 } from '@railgun-community/engine';
 import { assertNotBlockedAddress } from '../../utils/blocked-address';
-import { createRelayAdaptUnshieldERC20AmountRecipients } from './tx-cross-contract-calls';
 import { reportAndSanitizeError } from '../../utils/error';
+import {
+  createRelayAdapt7702UnshieldBaseTokenERC20AmountRecipients,
+  createUnshieldBaseTokenActionData7702,
+  createUnshieldBaseTokenTransaction7702,
+} from './tx-unshield-base-token-7702';
 
 export const generateUnshieldProof = async (
   txidVersion: TXIDVersion,
@@ -192,10 +198,17 @@ export const generateUnshieldBaseTokenProof = async (
       wrappedERC20Amount,
     ];
 
+    const ephemeralAddress = await getCurrentEphemeralAddress(
+      railgunWalletID,
+      encryptionKey,
+      networkName,
+    );
+
     const relayAdaptUnshieldERC20AmountRecipients: RailgunERC20AmountRecipient[] =
-      createRelayAdaptUnshieldERC20AmountRecipients(txidVersion, networkName, [
-        wrappedERC20Amount,
-      ]);
+      createRelayAdapt7702UnshieldBaseTokenERC20AmountRecipients(
+        [wrappedERC20Amount],
+        ephemeralAddress,
+      );
 
     // Empty NFT recipients.
     const nftAmountRecipients: RailgunNFTAmountRecipient[] = [];
@@ -220,26 +233,17 @@ export const generateUnshieldBaseTokenProof = async (
       mnemonicPassword,
     );
 
-    const { chain } = NETWORK_CONFIG[networkName];
+    const actionData = await createUnshieldBaseTokenActionData7702(
+      txidVersion,
+      networkName,
+      publicWalletAddress,
+      ephemeralAddress,
+      sendWithPublicWallet,
+    );
 
-    const relayAdaptParamsRandom = ByteUtils.randomHex(31);
-    const relayAdaptParams =
-      await RelayAdaptVersionedSmartContracts.getRelayAdaptParamsUnshieldBaseToken(
-        txidVersion,
-        chain,
-        dummyTxs,
-        publicWalletAddress,
-        relayAdaptParamsRandom,
-        sendWithPublicWallet,
-      );
-    const relayAdaptContract =
-      RelayAdaptVersionedSmartContracts.getRelayAdaptContract(
-        txidVersion,
-        chain,
-      );
     const relayAdaptID: AdaptID = {
-      contract: relayAdaptContract.address,
-      parameters: relayAdaptParams,
+      contract: ephemeralAddress,
+      parameters: RelayAdapt7702Helper.getZeroAdaptParams(),
     };
 
     const showSenderAddressToRecipient = false;
@@ -267,14 +271,14 @@ export const generateUnshieldBaseTokenProof = async (
         mnemonicPassword,
       );
 
-    const transaction = await generateUnshieldBaseToken(
+    const transaction = await createUnshieldBaseTokenTransaction7702(
       txidVersion,
-      provedTransactions,
       networkName,
-      publicWalletAddress,
-      relayAdaptParamsRandom,
-      false, // useDummyProof
-      sendWithPublicWallet,
+      railgunWalletID,
+      encryptionKey,
+      provedTransactions,
+      actionData,
+      ephemeralAddress,
     );
 
     const nullifiers = nullifiersForTransactions(provedTransactions);

--- a/src/services/transactions/tx-shield-base-token-7702.ts
+++ b/src/services/transactions/tx-shield-base-token-7702.ts
@@ -3,29 +3,17 @@ import {
   RelayAdapt7702,
   RelayAdapt__factory as RelayAdaptFactory,
   RelayAdapt7702Helper,
-  RelayAdapt7702__factory as RelayAdapt7702Factory,
   ShieldRequestStruct,
   TransactionStructV2,
 } from '@railgun-community/engine';
 import { Authorization, ContractTransaction } from 'ethers';
 import { reportAndSanitizeError } from '../../utils/error';
 import { EphemeralAccount } from '../railgun/wallets/ephemeral-account';
-
-const RELAY_ADAPT_7702_EXECUTE_SIGNATURE =
-  'execute((((uint256,uint256),(uint256[2],uint256[2]),(uint256,uint256)),bytes32,bytes32[],bytes32[],(uint16,uint72,uint8,uint64,address,bytes32,(bytes32[4],bytes32,bytes32,bytes,bytes)[]),(bytes32,(uint8,address,uint256),uint120))[],(bool,uint256,(address,bytes,uint256)[]),bytes)';
-
-const encodeRelayAdapt7702Execute = (
-  transactions: TransactionStructV2[],
-  actionData: RelayAdapt7702.ActionDataStruct,
-  signature: string,
-): string => {
-  const iface = RelayAdapt7702Factory.createInterface();
-  return (iface as any).encodeFunctionData(RELAY_ADAPT_7702_EXECUTE_SIGNATURE, [
-    transactions,
-    actionData,
-    signature,
-  ]);
-};
+import { getFallbackProviderForNetwork } from '../railgun/core/providers';
+import {
+  encodeRelayAdapt7702Execute,
+  getRelayAdapt7702ExecutionDetails,
+} from '../railgun/wallets/relay-adapt-7702-execution';
 
 export const createShieldBaseTokenActionData7702 = (
   txidVersion: TXIDVersion,
@@ -98,14 +86,26 @@ export const createShieldBaseTokenTransaction7702 = async (
       BigInt(network.chain.id),
       0,
     );
+    const provider = ephemeralAccount.signer.provider ?? getFallbackProviderForNetwork(networkName);
+    const executionDetails = await getRelayAdapt7702ExecutionDetails(
+      provider,
+      networkName,
+      ephemeralAddress,
+    );
     const signature = await RelayAdapt7702Helper.signExecutionAuthorization(
       ephemeralAccount.signer,
       transactions,
       actionData,
       BigInt(network.chain.id),
+      executionDetails,
     );
 
-    const data = encodeRelayAdapt7702Execute(transactions, actionData, signature);
+    const data = encodeRelayAdapt7702Execute(
+      transactions,
+      actionData,
+      signature,
+      executionDetails,
+    );
 
     return {
       to: ephemeralAddress,

--- a/src/services/transactions/tx-shield-base-token-7702.ts
+++ b/src/services/transactions/tx-shield-base-token-7702.ts
@@ -80,13 +80,19 @@ export const createShieldBaseTokenTransaction7702 = async (
     );
 
     const transactions: TransactionStructV2[] = [];
+    const provider = ephemeralAccount.signer.provider ?? getFallbackProviderForNetwork(networkName);
+    // The EIP-7702 authorization nonce must equal the ephemeral EOA's current account nonce
+    // (it increments each time an authorization for this account is applied). A literal 0 is
+    // correct only for a never-delegated account; a reused ephemeral account has a non-zero
+    // nonce, so 0 would be stale and the authorization silently skipped on-chain. Read it live,
+    // matching the cross-contract and unshield paths (getNonce('latest')).
+    const authorizationNonce = await provider.getTransactionCount(ephemeralAddress, 'latest');
     const authorization: Authorization = await RelayAdapt7702Helper.signEIP7702Authorization(
       ephemeralAccount.signer,
       relayAdapt7702Contract,
       BigInt(network.chain.id),
-      0,
+      authorizationNonce,
     );
-    const provider = ephemeralAccount.signer.provider ?? getFallbackProviderForNetwork(networkName);
     const executionDetails = await getRelayAdapt7702ExecutionDetails(
       provider,
       networkName,

--- a/src/services/transactions/tx-shield-base-token-7702.ts
+++ b/src/services/transactions/tx-shield-base-token-7702.ts
@@ -1,0 +1,120 @@
+import { NetworkName, NETWORK_CONFIG, TXIDVersion } from '@railgun-community/shared-models';
+import {
+  RelayAdapt7702,
+  RelayAdapt__factory as RelayAdaptFactory,
+  RelayAdapt7702Helper,
+  RelayAdapt7702__factory as RelayAdapt7702Factory,
+  ShieldRequestStruct,
+  TransactionStructV2,
+} from '@railgun-community/engine';
+import { Authorization, ContractTransaction } from 'ethers';
+import { reportAndSanitizeError } from '../../utils/error';
+import { EphemeralAccount } from '../railgun/wallets/ephemeral-account';
+
+const RELAY_ADAPT_7702_EXECUTE_SIGNATURE =
+  'execute((((uint256,uint256),(uint256[2],uint256[2]),(uint256,uint256)),bytes32,bytes32[],bytes32[],(uint16,uint72,uint8,uint64,address,bytes32,(bytes32[4],bytes32,bytes32,bytes,bytes)[]),(bytes32,(uint8,address,uint256),uint120))[],(bool,uint256,(address,bytes,uint256)[]),bytes)';
+
+const encodeRelayAdapt7702Execute = (
+  transactions: TransactionStructV2[],
+  actionData: RelayAdapt7702.ActionDataStruct,
+  signature: string,
+): string => {
+  const iface = RelayAdapt7702Factory.createInterface();
+  return (iface as any).encodeFunctionData(RELAY_ADAPT_7702_EXECUTE_SIGNATURE, [
+    transactions,
+    actionData,
+    signature,
+  ]);
+};
+
+export const createShieldBaseTokenActionData7702 = (
+  txidVersion: TXIDVersion,
+  shieldRequest: ShieldRequestStruct,
+  ephemeralAddress: string,
+): RelayAdapt7702.ActionDataStruct => {
+  if (txidVersion !== TXIDVersion.V2_PoseidonMerkle) {
+    throw new Error('7702 shield base-token is only supported for TXID V2.');
+  }
+
+  const relayAdaptInterface = RelayAdaptFactory.createInterface();
+
+  const calls: ContractTransaction[] = [
+    {
+      to: ephemeralAddress,
+      data: relayAdaptInterface.encodeFunctionData('wrapBase', [
+        shieldRequest.preimage.value,
+      ]),
+      value: 0n,
+    },
+    {
+      to: ephemeralAddress,
+      data: relayAdaptInterface.encodeFunctionData('shield', [[shieldRequest]]),
+      value: 0n,
+    },
+  ];
+
+  return RelayAdapt7702Helper.getActionData(
+    true,
+    calls,
+    BigInt(0),
+  );
+};
+
+export const createShieldBaseTokenTransaction7702 = async (
+  txidVersion: TXIDVersion,
+  networkName: NetworkName,
+  shieldRequest: ShieldRequestStruct,
+  ephemeralAccount: EphemeralAccount,
+): Promise<ContractTransaction> => {
+  try {
+    if (txidVersion !== TXIDVersion.V2_PoseidonMerkle) {
+      throw new Error('7702 shield base-token is only supported for TXID V2.');
+    }
+
+    const network = NETWORK_CONFIG[networkName];
+    const relayAdapt7702Contract = network.relayAdapt7702Contract;
+    if (!relayAdapt7702Contract) {
+      throw new Error(`Missing relayAdapt7702Contract for network ${networkName}.`);
+    }
+
+    if (!(ephemeralAccount instanceof EphemeralAccount)) {
+      throw new Error(
+        'Shield 7702 requires an EphemeralAccount signer.',
+      );
+    }
+
+    const ephemeralAddress = ephemeralAccount.address;
+
+    const actionData = createShieldBaseTokenActionData7702(
+      txidVersion,
+      shieldRequest,
+      ephemeralAddress,
+    );
+
+    const transactions: TransactionStructV2[] = [];
+    const authorization: Authorization = await RelayAdapt7702Helper.signEIP7702Authorization(
+      ephemeralAccount.signer,
+      relayAdapt7702Contract,
+      BigInt(network.chain.id),
+      0,
+    );
+    const signature = await RelayAdapt7702Helper.signExecutionAuthorization(
+      ephemeralAccount.signer,
+      transactions,
+      actionData,
+      BigInt(network.chain.id),
+    );
+
+    const data = encodeRelayAdapt7702Execute(transactions, actionData, signature);
+
+    return {
+      to: ephemeralAddress,
+      data,
+      value: BigInt(shieldRequest.preimage.value.toString()),
+      type: 4,
+      authorizationList: [authorization],
+    };
+  } catch (err) {
+    throw reportAndSanitizeError(createShieldBaseTokenTransaction7702.name, err);
+  }
+};

--- a/src/services/transactions/tx-shield-base-token.ts
+++ b/src/services/transactions/tx-shield-base-token.ts
@@ -22,6 +22,8 @@ import {
 import { reportAndSanitizeError } from '../../utils/error';
 import { ContractTransaction } from 'ethers';
 import { assertValidRailgunAddress } from '../railgun/wallets/wallets';
+import { createShieldBaseTokenTransaction7702 } from './tx-shield-base-token-7702';
+import { EphemeralAccount } from '../railgun/wallets/ephemeral-account';
 
 const generateShieldBaseTokenTransaction = async (
   txidVersion: TXIDVersion,
@@ -29,6 +31,7 @@ const generateShieldBaseTokenTransaction = async (
   railgunAddress: string,
   shieldPrivateKey: string,
   wrappedERC20Amount: RailgunERC20Amount,
+  ephemeralAccount?: EphemeralAccount,
 ): Promise<ContractTransaction> => {
   try {
     const { masterPublicKey, viewingPublicKey } =
@@ -49,9 +52,23 @@ const generateShieldBaseTokenTransaction = async (
       viewingPublicKey,
     );
 
-    const { chain } = NETWORK_CONFIG[networkName];
-    const transaction =
-      await RelayAdaptVersionedSmartContracts.populateShieldBaseToken(
+    const { chain, relayAdapt7702Contract } = NETWORK_CONFIG[networkName];
+
+    const has7702Support =
+      txidVersion === TXIDVersion.V2_PoseidonMerkle &&
+      typeof relayAdapt7702Contract === 'string' &&
+      relayAdapt7702Contract.length > 0;
+
+    const hasEphemeralAccount = ephemeralAccount instanceof EphemeralAccount;
+
+    const transaction = has7702Support && hasEphemeralAccount
+      ? await createShieldBaseTokenTransaction7702(
+        txidVersion,
+        networkName,
+        shieldRequest,
+        ephemeralAccount,
+      )
+      : await RelayAdaptVersionedSmartContracts.populateShieldBaseToken(
         txidVersion,
         chain,
         shieldRequest,
@@ -70,6 +87,7 @@ export const populateShieldBaseToken = async (
   shieldPrivateKey: string,
   wrappedERC20Amount: RailgunERC20Amount,
   gasDetails?: TransactionGasDetails,
+  ephemeralAccount?: EphemeralAccount,
 ): Promise<RailgunPopulateTransactionResponse> => {
   try {
     assertValidRailgunAddress(railgunAddress);
@@ -80,6 +98,7 @@ export const populateShieldBaseToken = async (
       railgunAddress,
       shieldPrivateKey,
       wrappedERC20Amount,
+      ephemeralAccount,
     );
 
     if (gasDetails) {
@@ -108,6 +127,7 @@ export const gasEstimateForShieldBaseToken = async (
   shieldPrivateKey: string,
   wrappedERC20Amount: RailgunERC20Amount,
   fromWalletAddress: string,
+  ephemeralAccount?: EphemeralAccount,
 ): Promise<RailgunTransactionGasEstimateResponse> => {
   try {
     assertValidRailgunAddress(railgunAddress);
@@ -119,6 +139,7 @@ export const gasEstimateForShieldBaseToken = async (
       railgunAddress,
       shieldPrivateKey,
       wrappedERC20Amount,
+      ephemeralAccount,
     );
 
     const sendWithPublicWallet = true;

--- a/src/services/transactions/tx-unshield-base-token-7702.ts
+++ b/src/services/transactions/tx-unshield-base-token-7702.ts
@@ -10,31 +10,15 @@ import {
   RelayAdapt7702,
   RelayAdapt__factory as RelayAdaptFactory,
   RelayAdapt7702Helper,
-  RelayAdapt7702__factory as RelayAdapt7702Factory,
   TransactionStructV2,
   TransactionStructV3,
 } from '@railgun-community/engine';
 import { ContractTransaction } from 'ethers';
 import { reportAndSanitizeError } from '../../utils/error';
 import { sign7702Request } from '../railgun/wallets/wallets';
-
-const RELAY_ADAPT_7702_EXECUTE_SIGNATURE =
-  'execute((((uint256,uint256),(uint256[2],uint256[2]),(uint256,uint256)),bytes32,bytes32[],bytes32[],(uint16,uint72,uint8,uint64,address,bytes32,(bytes32[4],bytes32,bytes32,bytes,bytes)[]),(bytes32,(uint8,address,uint256),uint120))[],(bool,uint256,(address,bytes,uint256)[]),bytes)';
+import { encodeRelayAdapt7702Execute } from '../railgun/wallets/relay-adapt-7702-execution';
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
-
-const encodeRelayAdapt7702Execute = (
-  transactions: TransactionStructV2[],
-  actionData: RelayAdapt7702.ActionDataStruct,
-  signature: string,
-): string => {
-  const iface = RelayAdapt7702Factory.createInterface();
-  return (iface as any).encodeFunctionData(RELAY_ADAPT_7702_EXECUTE_SIGNATURE, [
-    transactions,
-    actionData,
-    signature,
-  ]);
-};
 
 export const createRelayAdapt7702UnshieldBaseTokenERC20AmountRecipients = (
   unshieldERC20Amounts: RailgunERC20Amount[],
@@ -110,7 +94,7 @@ export const createUnshieldBaseTokenTransaction7702 = async (
       throw new Error(`Missing relayAdapt7702Contract for network ${networkName}.`);
     }
 
-    const { authorization, signature } = await sign7702Request(
+    const { authorization, signature, executionDetails } = await sign7702Request(
       railgunWalletID,
       encryptionKey,
       networkName,
@@ -124,6 +108,7 @@ export const createUnshieldBaseTokenTransaction7702 = async (
       transactions as TransactionStructV2[],
       actionData,
       signature,
+      executionDetails,
     );
 
     return {

--- a/src/services/transactions/tx-unshield-base-token-7702.ts
+++ b/src/services/transactions/tx-unshield-base-token-7702.ts
@@ -1,0 +1,139 @@
+import {
+  NetworkName,
+  NETWORK_CONFIG,
+  RailgunERC20Amount,
+  RailgunERC20AmountRecipient,
+  TXIDVersion,
+} from '@railgun-community/shared-models';
+import {
+  getTokenDataERC20,
+  RelayAdapt7702,
+  RelayAdapt__factory as RelayAdaptFactory,
+  RelayAdapt7702Helper,
+  RelayAdapt7702__factory as RelayAdapt7702Factory,
+  TransactionStructV2,
+  TransactionStructV3,
+} from '@railgun-community/engine';
+import { ContractTransaction } from 'ethers';
+import { reportAndSanitizeError } from '../../utils/error';
+import { sign7702Request } from '../railgun/wallets/wallets';
+
+const RELAY_ADAPT_7702_EXECUTE_SIGNATURE =
+  'execute((((uint256,uint256),(uint256[2],uint256[2]),(uint256,uint256)),bytes32,bytes32[],bytes32[],(uint16,uint72,uint8,uint64,address,bytes32,(bytes32[4],bytes32,bytes32,bytes,bytes)[]),(bytes32,(uint8,address,uint256),uint120))[],(bool,uint256,(address,bytes,uint256)[]),bytes)';
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+const encodeRelayAdapt7702Execute = (
+  transactions: TransactionStructV2[],
+  actionData: RelayAdapt7702.ActionDataStruct,
+  signature: string,
+): string => {
+  const iface = RelayAdapt7702Factory.createInterface();
+  return (iface as any).encodeFunctionData(RELAY_ADAPT_7702_EXECUTE_SIGNATURE, [
+    transactions,
+    actionData,
+    signature,
+  ]);
+};
+
+export const createRelayAdapt7702UnshieldBaseTokenERC20AmountRecipients = (
+  unshieldERC20Amounts: RailgunERC20Amount[],
+  ephemeralAddress: string,
+): RailgunERC20AmountRecipient[] => {
+  return unshieldERC20Amounts.map(unshieldERC20Amount => ({
+    ...unshieldERC20Amount,
+    recipientAddress: ephemeralAddress,
+  }));
+};
+
+export const createUnshieldBaseTokenActionData7702 = async (
+  txidVersion: TXIDVersion,
+  networkName: NetworkName,
+  unshieldAddress: string,
+  ephemeralAddress: string,
+  sendWithPublicWallet: boolean,
+): Promise<RelayAdapt7702.ActionDataStruct> => {
+  try {
+    if (txidVersion !== TXIDVersion.V2_PoseidonMerkle) {
+      throw new Error('7702 unshield base-token is only supported for TXID V2.');
+    }
+
+    const baseTokenData = getTokenDataERC20(ZERO_ADDRESS);
+    const relayAdaptInterface = RelayAdaptFactory.createInterface();
+
+    const calls: ContractTransaction[] = [
+      {
+        to: ephemeralAddress,
+        data: relayAdaptInterface.encodeFunctionData('unwrapBase', [0n]),
+        value: 0n,
+      },
+      {
+        to: ephemeralAddress,
+        data: relayAdaptInterface.encodeFunctionData('transfer', [[
+          {
+            token: baseTokenData,
+            to: unshieldAddress,
+            value: 0n,
+          },
+        ]]),
+        value: 0n,
+      },
+    ];
+
+    return RelayAdapt7702Helper.getActionData(
+      sendWithPublicWallet,
+      calls,
+      BigInt(0),
+    );
+  } catch (err) {
+    throw reportAndSanitizeError(createUnshieldBaseTokenActionData7702.name, err);
+  }
+};
+
+export const createUnshieldBaseTokenTransaction7702 = async (
+  txidVersion: TXIDVersion,
+  networkName: NetworkName,
+  railgunWalletID: string,
+  encryptionKey: string,
+  transactions: (TransactionStructV2 | TransactionStructV3)[],
+  actionData: RelayAdapt7702.ActionDataStruct,
+  ephemeralAddress: string,
+): Promise<ContractTransaction> => {
+  try {
+    if (txidVersion !== TXIDVersion.V2_PoseidonMerkle) {
+      throw new Error('7702 unshield base-token is only supported for TXID V2.');
+    }
+
+    const network = NETWORK_CONFIG[networkName];
+    const relayAdapt7702Contract = network.relayAdapt7702Contract;
+    if (!relayAdapt7702Contract) {
+      throw new Error(`Missing relayAdapt7702Contract for network ${networkName}.`);
+    }
+
+    const { authorization, signature } = await sign7702Request(
+      railgunWalletID,
+      encryptionKey,
+      networkName,
+      relayAdapt7702Contract,
+      BigInt(network.chain.id),
+      transactions as TransactionStructV2[],
+      actionData,
+    );
+
+    const data = encodeRelayAdapt7702Execute(
+      transactions as TransactionStructV2[],
+      actionData,
+      signature,
+    );
+
+    return {
+      to: ephemeralAddress,
+      data,
+      value: 0n,
+      type: 4,
+      authorizationList: [authorization],
+    };
+  } catch (err) {
+    throw reportAndSanitizeError(createUnshieldBaseTokenTransaction7702.name, err);
+  }
+};

--- a/src/services/transactions/tx-unshield-base-token-7702.ts
+++ b/src/services/transactions/tx-unshield-base-token-7702.ts
@@ -82,6 +82,7 @@ export const createUnshieldBaseTokenTransaction7702 = async (
   transactions: (TransactionStructV2 | TransactionStructV3)[],
   actionData: RelayAdapt7702.ActionDataStruct,
   ephemeralAddress: string,
+  mnemonicPassword?: string,
 ): Promise<ContractTransaction> => {
   try {
     if (txidVersion !== TXIDVersion.V2_PoseidonMerkle) {
@@ -102,6 +103,7 @@ export const createUnshieldBaseTokenTransaction7702 = async (
       BigInt(network.chain.id),
       transactions as TransactionStructV2[],
       actionData,
+      mnemonicPassword,
     );
 
     const data = encodeRelayAdapt7702Execute(

--- a/src/services/transactions/tx-unshield.ts
+++ b/src/services/transactions/tx-unshield.ts
@@ -15,7 +15,6 @@ import {
   DUMMY_FROM_ADDRESS,
   generateDummyProofTransactions,
   generateTransact,
-  generateUnshieldBaseToken,
 } from './tx-generator';
 import { populateProvedTransaction } from './proof-cache';
 import {
@@ -24,7 +23,6 @@ import {
   TransactionStructV3,
 } from '@railgun-community/engine';
 import { gasEstimateResponseDummyProofIterativeBroadcasterFee } from './tx-gas-broadcaster-fee-estimator';
-import { createRelayAdaptUnshieldERC20AmountRecipients } from './tx-cross-contract-calls';
 import { reportAndSanitizeError } from '../../utils/error';
 import { gasEstimateResponse, getGasEstimate } from './tx-gas-details';
 import {
@@ -34,6 +32,15 @@ import {
   getSerializedNFTBalances,
 } from '../railgun';
 import { TransactionReceipt, TransactionResponse } from 'ethers';
+import {
+  assertValidEthAddress,
+  getCurrentEphemeralAddress,
+} from '../railgun/wallets/wallets';
+import {
+  createRelayAdapt7702UnshieldBaseTokenERC20AmountRecipients,
+  createUnshieldBaseTokenActionData7702,
+  createUnshieldBaseTokenTransaction7702,
+} from './tx-unshield-base-token-7702';
 
 const ERC20_TRANSFER_EVENT_SIGNATURE = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
 
@@ -202,10 +209,19 @@ export const gasEstimateForUnprovenUnshieldBaseToken = async (
   mnemonicPassword?: string,
 ): Promise<RailgunTransactionGasEstimateResponse> => {
   try {
+    assertValidEthAddress(publicWalletAddress);
+
+    const ephemeralAddress = await getCurrentEphemeralAddress(
+      railgunWalletID,
+      encryptionKey,
+      networkName,
+    );
+
     const relayAdaptUnshieldERC20AmountRecipients: RailgunERC20AmountRecipient[] =
-      createRelayAdaptUnshieldERC20AmountRecipients(txidVersion, networkName, [
-        wrappedERC20Amount,
-      ]);
+      createRelayAdapt7702UnshieldBaseTokenERC20AmountRecipients(
+        [wrappedERC20Amount],
+        ephemeralAddress,
+      );
 
     // Empty NFT Recipients.
     const nftAmountRecipients: RailgunNFTAmountRecipient[] = [];
@@ -231,15 +247,22 @@ export const gasEstimateForUnprovenUnshieldBaseToken = async (
           mnemonicPassword,
         ),
       (txs: (TransactionStructV2 | TransactionStructV3)[]) => {
-        const relayAdaptParamsRandom = ByteUtils.randomHex(31);
-        return generateUnshieldBaseToken(
+        return createUnshieldBaseTokenActionData7702(
           txidVersion,
-          txs,
           networkName,
           publicWalletAddress,
-          relayAdaptParamsRandom,
-          true, // useDummyProof (for gas estimation)
+          ephemeralAddress,
           sendWithPublicWallet,
+        ).then(actionData =>
+          createUnshieldBaseTokenTransaction7702(
+            txidVersion,
+            networkName,
+            railgunWalletID,
+            encryptionKey,
+            txs,
+            actionData,
+            ephemeralAddress,
+          ),
         );
       },
       txidVersion,

--- a/src/services/transactions/tx-unshield.ts
+++ b/src/services/transactions/tx-unshield.ts
@@ -215,6 +215,7 @@ export const gasEstimateForUnprovenUnshieldBaseToken = async (
       railgunWalletID,
       encryptionKey,
       networkName,
+      mnemonicPassword,
     );
 
     const relayAdaptUnshieldERC20AmountRecipients: RailgunERC20AmountRecipient[] =
@@ -262,6 +263,7 @@ export const gasEstimateForUnprovenUnshieldBaseToken = async (
             txs,
             actionData,
             ephemeralAddress,
+            mnemonicPassword,
           ),
         );
       },


### PR DESCRIPTION
This pull request introduces support for EIP-7702 relay-adapt contracts and ephemeral account management, along with related utilities and comprehensive tests. Key changes include adding new modules for ephemeral key management, extending provider loading logic to handle 7702 contracts, and implementing execution helpers for relay-adapt-7702. The update also increases the provider polling interval and adds robust test coverage for the new functionality.

**EIP-7702 and Relay-Adapt Contract Integration:**

* Added logic in `load-provider.ts` to detect and load relay-adapt-7702 contracts and their execution types, including support for `relayAdapt7702Contract` and `railgunRegistryContract` when the network supports 7702. The provider polling interval was also increased to 60 seconds. [[1]](diffhunk://#diff-1932e31082788094813e292af1fe068d2f635cdaf128674b4aed53d0d0118cabR21) [[2]](diffhunk://#diff-1932e31082788094813e292af1fe068d2f635cdaf128674b4aed53d0d0118cabR97-R99) [[3]](diffhunk://#diff-1932e31082788094813e292af1fe068d2f635cdaf128674b4aed53d0d0118cabR123-R132) [[4]](diffhunk://#diff-1932e31082788094813e292af1fe068d2f635cdaf128674b4aed53d0d0118cabR147-R149) [[5]](diffhunk://#diff-1932e31082788094813e292af1fe068d2f635cdaf128674b4aed53d0d0118cabL143-R160)
* Updated `poi-validation.ts` and `extract-transaction-data.ts` to support a `useRelayAdapt7702` parameter, ensuring correct contract address selection and transaction handling for 7702-enabled flows. [[1]](diffhunk://#diff-d44cebba6d6dcb676fa756146fa474fec1d3e6d11541e184e1639196db69a98cR29) [[2]](diffhunk://#diff-d44cebba6d6dcb676fa756146fa474fec1d3e6d11541e184e1639196db69a98cR45) [[3]](diffhunk://#diff-d44cebba6d6dcb676fa756146fa474fec1d3e6d11541e184e1639196db69a98cR62) [[4]](diffhunk://#diff-a77d16a6ede7904e5c2149d773e5d0f6c897bb0353ec1c677562e99d90b2783bR12) [[5]](diffhunk://#diff-a77d16a6ede7904e5c2149d773e5d0f6c897bb0353ec1c677562e99d90b2783bR21) [[6]](diffhunk://#diff-a77d16a6ede7904e5c2149d773e5d0f6c897bb0353ec1c677562e99d90b2783bR37)

**Ephemeral Account and Key Management:**

* Introduced new modules `ephemeral-account.ts` and `ephemeral-key-manager.ts` to manage ephemeral accounts and indexes, with logic to scan transaction history for index recovery. [[1]](diffhunk://#diff-addf04e11d3a10b668600d2d013c4d2bc1528449c961cec6aef46fe0fb7e8786R1-R17) [[2]](diffhunk://#diff-58507bc0fc66ffe749f65b311147ce02dd3bd664a3f09b50abea65a660fd92f3R1-R82)
* Exported the new ephemeral account management modules from the wallet index.

**Relay-Adapt-7702 Execution Utilities:**

* Added `relay-adapt-7702-execution.ts` with helpers to determine execution type per network, read/handle execute nonces, and encode relay-adapt-7702 execute calls.

**Testing:**

* Added comprehensive tests for ephemeral key manager and relay-adapt-7702 execution logic, covering edge cases and error handling. [[1]](diffhunk://#diff-cf9762dd845898faffca171e0b738f13e1977f40d5785e8eef5a67bde279d73dR1-R124) [[2]](diffhunk://#diff-16a105431d8bb2996a3145a650c8dc0a3d8499e5c3b2b754de2d60d63acd18d5R1-R141)

**Miscellaneous:**

* Updated wallet imports to include new types and utilities for relay-adapt-7702 and ephemeral account management. [[1]](diffhunk://#diff-a97d7266539b3b125f02e6d21c686094cec734672409e0448a0450301d094d02R1) [[2]](diffhunk://#diff-a97d7266539b3b125f02e6d21c686094cec734672409e0448a0450301d094d02R13-R16)

These changes collectively enable advanced ephemeral account workflows and support for EIP-7702 relay-adapt contracts, improving flexibility and future-proofing the wallet infrastructure.