### PR TITLE
Allow 7702 cross-contract calls to target a specific ephemeral account

### DIFF
--- a/src/services/railgun/wallets/wallets.ts
+++ b/src/services/railgun/wallets/wallets.ts
@@ -428,6 +428,7 @@ export const sign7702Request = async (
   transactions: (TransactionStructV2 | TransactionStructV3)[],
   actionData: RelayAdapt7702.ActionDataStruct,
   mnemonicPassword?: string,
+  ephemeralIndex?: number,
 ): Promise<{
   authorization: Authorization;
   signature: string;
@@ -435,40 +436,59 @@ export const sign7702Request = async (
 }> => {
   const wallet = fullWalletForID(walletID);
   const provider = getFallbackProviderForNetwork(networkName);
-  // Single-source every ephemeral facet on the signer that will actually produce the
-  // authorization below. getCurrentEphemeralAddress resolves the signer's address (honoring the
-  // same override/provider precedence as sign7702Request), so the authorization nonce and the
-  // execute nonce are read from the authorization authority itself. Reading them from
-  // getCurrentEphemeralWallet instead desyncs when a custom signer provider is set (authority
-  // != nonce-source), which silently invalidates the on-chain authorization.
-  const ephemeralAddress = await wallet.getCurrentEphemeralAddress(
-    encryptionKey,
-    chainId,
-    mnemonicPassword,
-  );
-  const nonce = await provider.getTransactionCount(ephemeralAddress, 'latest');
-  const executionDetails = await getRelayAdapt7702ExecutionDetails(
-    provider,
-    networkName,
-    ephemeralAddress,
-  );
 
-  const { authorization, signature } = await wallet.sign7702Request(
-    encryptionKey,
-    contractAddress,
-    chainId,
-    transactions,
-    actionData,
-    nonce,
-    executionDetails,
-    mnemonicPassword,
-  );
+  // The engine reads the override ahead of both the stored index and any custom signer provider,
+  // so pinning it here keeps the authorization authority, the `to` address and the nonce on one
+  // account. It is restored below: the override is shared state on the wallet.
+  const previousEphemeralWalletOverride = wallet.ephemeralWalletOverride;
+  if (isDefined(ephemeralIndex)) {
+    assertCanonicalEphemeralProvider(wallet);
+    wallet.ephemeralWalletOverride = await wallet.getEphemeralWallet(
+      encryptionKey,
+      chainId,
+      ephemeralIndex,
+      mnemonicPassword,
+    );
+  }
 
-  return {
-    authorization,
-    signature,
-    executionDetails,
-  };
+  try {
+    // Single-source every ephemeral facet on the signer that will actually produce the
+    // authorization below. getCurrentEphemeralAddress resolves the signer's address (honoring the
+    // same override/provider precedence as sign7702Request), so the authorization nonce and the
+    // execute nonce are read from the authorization authority itself. Reading them from
+    // getCurrentEphemeralWallet instead desyncs when a custom signer provider is set (authority
+    // != nonce-source), which silently invalidates the on-chain authorization.
+    const ephemeralAddress = await wallet.getCurrentEphemeralAddress(
+      encryptionKey,
+      chainId,
+      mnemonicPassword,
+    );
+    const nonce = await provider.getTransactionCount(ephemeralAddress, 'latest');
+    const executionDetails = await getRelayAdapt7702ExecutionDetails(
+      provider,
+      networkName,
+      ephemeralAddress,
+    );
+
+    const { authorization, signature } = await wallet.sign7702Request(
+      encryptionKey,
+      contractAddress,
+      chainId,
+      transactions,
+      actionData,
+      nonce,
+      executionDetails,
+      mnemonicPassword,
+    );
+
+    return {
+      authorization,
+      signature,
+      executionDetails,
+    };
+  } finally {
+    wallet.ephemeralWalletOverride = previousEphemeralWalletOverride;
+  }
 };
 
 export const ratchetEphemeralAddress = async (
@@ -478,6 +498,38 @@ export const ratchetEphemeralAddress = async (
   const wallet = fullWalletForID(walletID);
   const chainId = BigInt(NETWORK_CONFIG[networkName].chain.id);
   return wallet.ratchetEphemeralAddress(chainId);
+};
+
+// A custom ephemeral signer provider (eg. a hardware wallet) owns keys the engine cannot derive
+// from an integer index, so pinning an index there would sign with an unrelated mnemonic-derived
+// account. Callers that target an index must be on the canonical HD provider.
+const assertCanonicalEphemeralProvider = (wallet: RailgunWallet) => {
+  if (!wallet.isCanonicalEphemeralProvider()) {
+    throw new Error(
+      'Cannot target an ephemeral account by index: this wallet uses a custom ephemeral signer provider.',
+    );
+  }
+};
+
+// Resolves the address of a specific ephemeral account, so funds left behind on a rotated account
+// stay reachable. `getCurrentEphemeralAddress` covers the common case of the account in use now.
+export const getEphemeralAddressForIndex = async (
+  walletID: string,
+  encryptionKey: string,
+  networkName: NetworkName,
+  ephemeralIndex: number,
+  mnemonicPassword?: string,
+): Promise<string> => {
+  const wallet = fullWalletForID(walletID);
+  assertCanonicalEphemeralProvider(wallet);
+  const chainId = BigInt(NETWORK_CONFIG[networkName].chain.id);
+  const ephemeralWallet = await wallet.getEphemeralWallet(
+    encryptionKey,
+    chainId,
+    ephemeralIndex,
+    mnemonicPassword,
+  );
+  return ephemeralWallet.address;
 };
 
 export const getCurrentEphemeralAddress = async (

--- a/src/services/transactions/tx-cross-contract-calls-7702.ts
+++ b/src/services/transactions/tx-cross-contract-calls-7702.ts
@@ -12,6 +12,7 @@ import {
   EVMGasType,
   TXIDVersion,
   NETWORK_CONFIG,
+  isDefined,
 } from '@railgun-community/shared-models';
 import {
   GenerateTransactionsProgressCallback,
@@ -44,7 +45,11 @@ import { ContractTransaction } from 'ethers';
 import {
   createRelayAdaptShieldNFTRecipients,
 } from './tx-cross-contract-calls';
-import { getCurrentEphemeralAddress, sign7702Request } from '../railgun/wallets/wallets';
+import {
+  getCurrentEphemeralAddress,
+  getEphemeralAddressForIndex,
+  sign7702Request,
+} from '../railgun/wallets/wallets';
 import { encodeRelayAdapt7702Execute } from '../railgun/wallets/relay-adapt-7702-execution';
 
 
@@ -152,6 +157,7 @@ export const gasEstimateForUnprovenCrossContractCalls7702 = async (
   sendWithPublicWallet: boolean,
   minGasLimit: Optional<bigint>,
   mnemonicPassword?: string,
+  ephemeralIndex?: number,
 ): Promise<RailgunTransactionGasEstimateResponse> => {
   try {
     setCachedProvedTransaction(undefined);
@@ -165,12 +171,20 @@ export const gasEstimateForUnprovenCrossContractCalls7702 = async (
     const validCrossContractCalls =
       createValidCrossContractCalls(crossContractCalls);
 
-    const ephemeralAddress = await getCurrentEphemeralAddress(
-      railgunWalletID,
-      encryptionKey,
-      networkName,
-      mnemonicPassword,
-    );
+    const ephemeralAddress = isDefined(ephemeralIndex)
+      ? await getEphemeralAddressForIndex(
+          railgunWalletID,
+          encryptionKey,
+          networkName,
+          ephemeralIndex,
+          mnemonicPassword,
+        )
+      : await getCurrentEphemeralAddress(
+          railgunWalletID,
+          encryptionKey,
+          networkName,
+          mnemonicPassword,
+        );
 
     const relayAdaptUnshieldERC20AmountRecipients =
       createRelayAdapt7702UnshieldERC20AmountRecipients(
@@ -233,6 +247,7 @@ export const gasEstimateForUnprovenCrossContractCalls7702 = async (
           transactions,
           actionData,
           mnemonicPassword,
+          ephemeralIndex,
         );
 
         const data = encodeRelayAdapt7702Execute(
@@ -318,6 +333,7 @@ export const generateCrossContractCallsProof7702 = async (
   minGasLimit: Optional<bigint>,
   progressCallback: GenerateTransactionsProgressCallback,
   mnemonicPassword?: string,
+  ephemeralIndex?: number,
 ): Promise<RelayAdapt7702Request> => {
   try {
     setCachedProvedTransaction(undefined);
@@ -325,12 +341,20 @@ export const generateCrossContractCallsProof7702 = async (
     const validCrossContractCalls =
       createValidCrossContractCalls(crossContractCalls);
 
-    const ephemeralAddress = await getCurrentEphemeralAddress(
-      railgunWalletID,
-      encryptionKey,
-      networkName,
-      mnemonicPassword,
-    );
+    const ephemeralAddress = isDefined(ephemeralIndex)
+      ? await getEphemeralAddressForIndex(
+          railgunWalletID,
+          encryptionKey,
+          networkName,
+          ephemeralIndex,
+          mnemonicPassword,
+        )
+      : await getCurrentEphemeralAddress(
+          railgunWalletID,
+          encryptionKey,
+          networkName,
+          mnemonicPassword,
+        );
 
     const relayAdaptUnshieldERC20AmountRecipients =
       createRelayAdapt7702UnshieldERC20AmountRecipients(
@@ -426,6 +450,7 @@ export const generateCrossContractCallsProof7702 = async (
       transactions,
       actionData,
       mnemonicPassword,
+      ephemeralIndex,
     );
 
     // Construct the transaction data


### PR DESCRIPTION
Funds can be stranded on an ephemeral account once the index rotates past it — a swap that reverts on slippage leaves them behind. The 7702 cross-contract entry points resolve the ephemeral account internally through `getCurrentEphemeralAddress`, so a caller cannot build a batch against the account that actually holds the funds and they stay unreachable.

This adds an optional trailing `ephemeralIndex` to `gasEstimateForUnprovenCrossContractCalls7702` and `generateCrossContractCallsProof7702`. When set, the unshield recipient, the EIP-7702 authorization authority and the nonce all resolve to that one account, reusing the engine's existing `ephemeralWalletOverride` scoped in a `try/finally` so the shared override is always restored. Omit it and behaviour is byte-identical to today.

Draft for your call on two things: whether you want this in #131 rather than stacked on it, and whether the unshield paths (`tx-unshield`, `tx-unshield-base-token-7702`, `tx-proof-unshield`) should take the same parameter — they still hard-wire the current account.
